### PR TITLE
Add flight model and screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,5 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'screens/home_screen.dart';
 
 void main() {
   runApp(const SkyBookApp());
@@ -14,110 +12,7 @@ class SkyBookApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: 'SkyBook',
-      home: FlightLogPage(),
-    );
-  }
-}
-
-class FlightLogPage extends StatefulWidget {
-  const FlightLogPage({super.key});
-
-  @override
-  State<FlightLogPage> createState() => _FlightLogPageState();
-}
-
-class _FlightLogPageState extends State<FlightLogPage> {
-  final _dateController = TextEditingController();
-  final _aircraftController = TextEditingController();
-  final _durationController = TextEditingController();
-  final _notesController = TextEditingController();
-
-  List<Map<String, dynamic>> _flights = [];
-
-  @override
-  void initState() {
-    super.initState();
-    _loadFlights();
-  }
-
-  Future<void> _loadFlights() async {
-    final prefs = await SharedPreferences.getInstance();
-    final stored = prefs.getString('flights');
-    if (stored != null) {
-      setState(() {
-        _flights = List<Map<String, dynamic>>.from(json.decode(stored));
-      });
-    }
-  }
-
-  Future<void> _saveFlights() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('flights', json.encode(_flights));
-  }
-
-  void _addFlight() {
-    final newFlight = {
-      'id': DateTime.now().millisecondsSinceEpoch.toString(),
-      'date': _dateController.text,
-      'aircraft': _aircraftController.text,
-      'duration': _durationController.text,
-      'notes': _notesController.text,
-    };
-    setState(() {
-      _flights.insert(0, newFlight);
-    });
-    _saveFlights();
-    _dateController.clear();
-    _aircraftController.clear();
-    _durationController.clear();
-    _notesController.clear();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('SkyBook')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _dateController,
-              decoration: const InputDecoration(labelText: 'Date'),
-            ),
-            TextField(
-              controller: _aircraftController,
-              decoration: const InputDecoration(labelText: 'Aircraft'),
-            ),
-            TextField(
-              controller: _durationController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'Duration (hrs)'),
-            ),
-            TextField(
-              controller: _notesController,
-              decoration: const InputDecoration(labelText: 'Notes'),
-              maxLines: 3,
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(onPressed: _addFlight, child: const Text('Add Flight')),
-            Expanded(
-              child: ListView.builder(
-                itemCount: _flights.length,
-                itemBuilder: (context, index) {
-                  final flight = _flights[index];
-                  final notes = flight['notes'] as String? ?? '';
-                  return ListTile(
-                    title: Text(
-                        '${flight['date']} - ${flight['aircraft']} - ${flight['duration']} hrs'),
-                    subtitle: notes.isNotEmpty ? Text(notes) : null,
-                  );
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
+      home: HomeScreen(),
     );
   }
 }

--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -1,0 +1,35 @@
+class Flight {
+  final String id;
+  final String date;
+  final String aircraft;
+  final String duration;
+  final String notes;
+
+  Flight({
+    required this.id,
+    required this.date,
+    required this.aircraft,
+    required this.duration,
+    required this.notes,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'date': date,
+      'aircraft': aircraft,
+      'duration': duration,
+      'notes': notes,
+    };
+  }
+
+  factory Flight.fromMap(Map<String, dynamic> map) {
+    return Flight(
+      id: map['id'] as String,
+      date: map['date'] as String,
+      aircraft: map['aircraft'] as String,
+      duration: map['duration'] as String,
+      notes: map['notes'] as String? ?? '',
+    );
+  }
+}

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../models/flight.dart';
+
+class AddFlightScreen extends StatefulWidget {
+  const AddFlightScreen({super.key});
+
+  @override
+  State<AddFlightScreen> createState() => _AddFlightScreenState();
+}
+
+class _AddFlightScreenState extends State<AddFlightScreen> {
+  final _dateController = TextEditingController();
+  final _aircraftController = TextEditingController();
+  final _durationController = TextEditingController();
+  final _notesController = TextEditingController();
+
+  void _submit() {
+    final flight = Flight(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      date: _dateController.text,
+      aircraft: _aircraftController.text,
+      duration: _durationController.text,
+      notes: _notesController.text,
+    );
+    Navigator.of(context).pop(flight);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Flight')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _dateController,
+              decoration: const InputDecoration(labelText: 'Date'),
+            ),
+            TextField(
+              controller: _aircraftController,
+              decoration: const InputDecoration(labelText: 'Aircraft'),
+            ),
+            TextField(
+              controller: _durationController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Duration (hrs)'),
+            ),
+            TextField(
+              controller: _notesController,
+              decoration: const InputDecoration(labelText: 'Notes'),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(onPressed: _submit, child: const Text('Add Flight')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/flight.dart';
+import '../widgets/flight_tile.dart';
+import 'add_flight_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  List<Flight> _flights = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFlights();
+  }
+
+  Future<void> _loadFlights() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString('flights');
+    if (stored != null) {
+      final List<dynamic> decoded = json.decode(stored);
+      setState(() {
+        _flights = decoded.map((e) => Flight.fromMap(e)).toList();
+      });
+    }
+  }
+
+  Future<void> _saveFlights() async {
+    final prefs = await SharedPreferences.getInstance();
+    final encoded = json.encode(_flights.map((f) => f.toMap()).toList());
+    await prefs.setString('flights', encoded);
+  }
+
+  Future<void> _addFlight() async {
+    final newFlight = await Navigator.of(context).push<Flight>(
+      MaterialPageRoute(builder: (_) => const AddFlightScreen()),
+    );
+    if (newFlight != null) {
+      setState(() {
+        _flights.insert(0, newFlight);
+      });
+      _saveFlights();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('SkyBook')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addFlight,
+        child: const Icon(Icons.add),
+      ),
+      body: ListView.builder(
+        itemCount: _flights.length,
+        itemBuilder: (context, index) {
+          return FlightTile(flight: _flights[index]);
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import '../models/flight.dart';
+
+class FlightTile extends StatelessWidget {
+  final Flight flight;
+
+  const FlightTile({super.key, required this.flight});
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = flight.notes;
+    return ListTile(
+      title: Text('${flight.date} - ${flight.aircraft} - ${flight.duration} hrs'),
+      subtitle: notes.isNotEmpty ? Text(notes) : null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `Flight` data model
- add `HomeScreen` and `AddFlightScreen`
- build reusable `FlightTile` widget
- update main entrypoint to use new screens

## Testing
- `dart format -o write lib` *(fails: `bash: dart: command not found`)*