### PR TITLE
Add editable Flights section

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'screens/home_screen.dart';
+import 'screens/flight_screen.dart';
 
 void main() {
   runApp(const SkyBookApp());
@@ -12,7 +12,7 @@ class SkyBookApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: 'SkyBook',
-      home: HomeScreen(),
+      home: FlightScreen(),
     );
   }
 }

--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -4,6 +4,7 @@ class Flight {
   final String aircraft;
   final String duration;
   final String notes;
+  final bool isFavorite;
 
   Flight({
     required this.id,
@@ -11,6 +12,7 @@ class Flight {
     required this.aircraft,
     required this.duration,
     required this.notes,
+    this.isFavorite = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -20,6 +22,7 @@ class Flight {
       'aircraft': aircraft,
       'duration': duration,
       'notes': notes,
+      'isFavorite': isFavorite,
     };
   }
 
@@ -30,6 +33,7 @@ class Flight {
       aircraft: map['aircraft'] as String,
       duration: map['duration'] as String,
       notes: map['notes'] as String? ?? '',
+      isFavorite: map['isFavorite'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import '../models/flight.dart';
 
 class AddFlightScreen extends StatefulWidget {
-  const AddFlightScreen({super.key});
+  final Flight? flight;
+
+  const AddFlightScreen({super.key, this.flight});
 
   @override
   State<AddFlightScreen> createState() => _AddFlightScreenState();
@@ -14,13 +16,26 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   final _durationController = TextEditingController();
   final _notesController = TextEditingController();
 
+  @override
+  void initState() {
+    super.initState();
+    final flight = widget.flight;
+    if (flight != null) {
+      _dateController.text = flight.date;
+      _aircraftController.text = flight.aircraft;
+      _durationController.text = flight.duration;
+      _notesController.text = flight.notes;
+    }
+  }
+
   void _submit() {
     final flight = Flight(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: widget.flight?.id ?? DateTime.now().millisecondsSinceEpoch.toString(),
       date: _dateController.text,
       aircraft: _aircraftController.text,
       duration: _durationController.text,
       notes: _notesController.text,
+      isFavorite: widget.flight?.isFavorite ?? false,
     );
     Navigator.of(context).pop(flight);
   }
@@ -28,7 +43,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Flight')),
+      appBar: AppBar(
+        title: Text(widget.flight == null ? 'Add Flight' : 'Edit Flight'),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -52,7 +69,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
               maxLines: 3,
             ),
             const SizedBox(height: 8),
-            ElevatedButton(onPressed: _submit, child: const Text('Add Flight')),
+            ElevatedButton(
+              onPressed: _submit,
+              child: Text(widget.flight == null ? 'Add Flight' : 'Save Changes'),
+            ),
           ],
         ),
       ),

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -7,14 +7,14 @@ import '../models/flight.dart';
 import '../widgets/flight_tile.dart';
 import 'add_flight_screen.dart';
 
-class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+class FlightScreen extends StatefulWidget {
+  const FlightScreen({super.key});
 
   @override
-  State<HomeScreen> createState() => _HomeScreenState();
+  State<FlightScreen> createState() => _FlightScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _FlightScreenState extends State<FlightScreen> {
   List<Flight> _flights = [];
 
   @override
@@ -52,10 +52,39 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
+  Future<void> _editFlight(int index) async {
+    final updated = await Navigator.of(context).push<Flight>(
+      MaterialPageRoute(
+        builder: (_) => AddFlightScreen(flight: _flights[index]),
+      ),
+    );
+    if (updated != null) {
+      setState(() {
+        _flights[index] = updated;
+      });
+      _saveFlights();
+    }
+  }
+
+  void _toggleFavorite(int index) {
+    final flight = _flights[index];
+    setState(() {
+      _flights[index] = Flight(
+        id: flight.id,
+        date: flight.date,
+        aircraft: flight.aircraft,
+        duration: flight.duration,
+        notes: flight.notes,
+        isFavorite: !flight.isFavorite,
+      );
+    });
+    _saveFlights();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('SkyBook')),
+      appBar: AppBar(title: const Text('Flights')),
       floatingActionButton: FloatingActionButton(
         onPressed: _addFlight,
         child: const Icon(Icons.add),
@@ -63,7 +92,11 @@ class _HomeScreenState extends State<HomeScreen> {
       body: ListView.builder(
         itemCount: _flights.length,
         itemBuilder: (context, index) {
-          return FlightTile(flight: _flights[index]);
+          return FlightTile(
+            flight: _flights[index],
+            onEdit: () => _editFlight(index),
+            onToggleFavorite: () => _toggleFavorite(index),
+          );
         },
       ),
     );

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -3,8 +3,15 @@ import '../models/flight.dart';
 
 class FlightTile extends StatelessWidget {
   final Flight flight;
+  final VoidCallback onEdit;
+  final VoidCallback onToggleFavorite;
 
-  const FlightTile({super.key, required this.flight});
+  const FlightTile({
+    super.key,
+    required this.flight,
+    required this.onEdit,
+    required this.onToggleFavorite,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -12,6 +19,21 @@ class FlightTile extends StatelessWidget {
     return ListTile(
       title: Text('${flight.date} - ${flight.aircraft} - ${flight.duration} hrs'),
       subtitle: notes.isNotEmpty ? Text(notes) : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(
+              flight.isFavorite ? Icons.star : Icons.star_border,
+            ),
+            onPressed: onToggleFavorite,
+          ),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: onEdit,
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add `isFavorite` property to `Flight` model
- reuse `AddFlightScreen` for editing existing flights
- rename and expand `HomeScreen` to `FlightScreen`
- allow editing flights and toggling favorites
- show favorite and edit icons in `FlightTile`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`