### PR TITLE
Add settings screen and map placeholder

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,10 @@ class _SkyBookAppState extends State<SkyBookApp> {
       ),
       darkTheme: ThemeData.dark(useMaterial3: true),
       themeMode: _darkMode ? ThemeMode.dark : ThemeMode.light,
-      home: HomeScreen(onToggleTheme: _toggleTheme),
+      home: HomeScreen(
+        onToggleTheme: _toggleTheme,
+        darkMode: _darkMode,
+      ),
     );
   }
 }

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -4,9 +4,11 @@ import '../models/flight.dart';
 import '../models/flight_storage.dart';
 import '../widgets/flight_tile.dart';
 import 'add_flight_screen.dart';
+import 'settings_screen.dart';
 
 class FlightScreen extends StatefulWidget {
-  const FlightScreen({super.key});
+  final VoidCallback onOpenSettings;
+  const FlightScreen({super.key, required this.onOpenSettings});
 
   @override
   State<FlightScreen> createState() => _FlightScreenState();
@@ -76,20 +78,40 @@ class _FlightScreenState extends State<FlightScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Flights')),
+      appBar: AppBar(
+        title: const Text('Flights'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: widget.onOpenSettings,
+          ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _addFlight,
         child: const Icon(Icons.add),
       ),
-      body: ListView.builder(
-        itemCount: _flights.length,
-        itemBuilder: (context, index) {
-          return FlightTile(
-            flight: _flights[index],
-            onEdit: () => _editFlight(index),
-            onToggleFavorite: () => _toggleFavorite(index),
-          );
-        },
+      body: Column(
+        children: [
+          Container(
+            height: 150,
+            color: Colors.grey.shade300,
+            alignment: Alignment.center,
+            child: const Text('Map placeholder'),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _flights.length,
+              itemBuilder: (context, index) {
+                return FlightTile(
+                  flight: _flights[index],
+                  onEdit: () => _editFlight(index),
+                  onToggleFavorite: () => _toggleFavorite(index),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import 'flight_screen.dart';
 import 'status_screen.dart';
+import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   final VoidCallback onToggleTheme;
-  const HomeScreen({super.key, required this.onToggleTheme});
+  final bool darkMode;
+  const HomeScreen({super.key, required this.onToggleTheme, required this.darkMode});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -14,15 +16,15 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   int _selectedIndex = 0;
 
-  late final List<Widget> _pages;
-
-  @override
-  void initState() {
-    super.initState();
-    _pages = [
-      const FlightScreen(),
-      StatusScreen(onToggleTheme: widget.onToggleTheme),
-    ];
+  void _openSettings() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => SettingsScreen(
+          darkMode: widget.darkMode,
+          onToggleTheme: widget.onToggleTheme,
+        ),
+      ),
+    );
   }
 
   void _onItemTapped(int index) {
@@ -33,8 +35,13 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final pages = [
+      FlightScreen(onOpenSettings: _openSettings),
+      StatusScreen(onOpenSettings: _openSettings),
+    ];
+
     return Scaffold(
-      body: IndexedStack(index: _selectedIndex, children: _pages),
+      body: IndexedStack(index: _selectedIndex, children: pages),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  final bool darkMode;
+  final VoidCallback onToggleTheme;
+
+  const SettingsScreen({
+    super.key,
+    required this.darkMode,
+    required this.onToggleTheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Dark Mode'),
+            value: darkMode,
+            onChanged: (_) => onToggleTheme(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -4,8 +4,8 @@ import '../models/flight.dart';
 import '../models/flight_storage.dart';
 
 class StatusScreen extends StatefulWidget {
-  final VoidCallback onToggleTheme;
-  const StatusScreen({super.key, required this.onToggleTheme});
+  final VoidCallback onOpenSettings;
+  const StatusScreen({super.key, required this.onOpenSettings});
 
   @override
   State<StatusScreen> createState() => _StatusScreenState();
@@ -41,8 +41,8 @@ class _StatusScreenState extends State<StatusScreen> {
         title: const Text('Status'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.color_lens),
-            onPressed: widget.onToggleTheme,
+            icon: const Icon(Icons.settings),
+            onPressed: widget.onOpenSettings,
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add SettingsScreen with dark mode switch
- pass theme state to HomeScreen
- show gear icon on each screen to open Settings
- include placeholder container for future map on Flights screen

## Testing
- `flutter --version` *(fails: command not found)*