### PR TITLE
Add progress screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Add flights with date, aircraft, duration and optional notes
 - View a list of all recorded flights
 - View overall stats like total flights and hours
+- Track progress with simple achievements
 - Switch between light and dark themes
 - Enable a developer section with an option to clear local data
 - Data is stored locally on the device
-- Quickly access sections using the bottom navigation bar
+- Quickly access Flights, Progress and Status using the bottom navigation bar
 
 ## Getting Started
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'flight_screen.dart';
 import 'status_screen.dart';
+import 'progress_screen.dart';
 import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -37,6 +38,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     final pages = [
       FlightScreen(onOpenSettings: _openSettings),
+      ProgressScreen(onOpenSettings: _openSettings),
       StatusScreen(onOpenSettings: _openSettings),
     ];
 
@@ -47,6 +49,7 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: _onItemTapped,
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.flight), label: 'Flights'),
+          BottomNavigationBarItem(icon: Icon(Icons.trending_up), label: 'Progress'),
           BottomNavigationBarItem(icon: Icon(Icons.assessment), label: 'Status'),
         ],
       ),

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../models/flight.dart';
+import '../models/flight_storage.dart';
+
+class ProgressScreen extends StatefulWidget {
+  final VoidCallback onOpenSettings;
+  const ProgressScreen({super.key, required this.onOpenSettings});
+
+  @override
+  State<ProgressScreen> createState() => _ProgressScreenState();
+}
+
+class _ProgressScreenState extends State<ProgressScreen> {
+  List<Flight> _flights = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFlights();
+  }
+
+  Future<void> _loadFlights() async {
+    final flights = await FlightStorage.loadFlights();
+    setState(() {
+      _flights = flights;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Progress'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: widget.onOpenSettings,
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _loadFlights,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(16),
+          children: [
+            _buildProgressSection(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressSection() {
+    if (_flights.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final achievements = <String>[];
+    if (_flights.length >= 1) achievements.add('1st flight logged');
+    if (_flights.length >= 10) achievements.add('10 flights logged');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Progress', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ...achievements.map((a) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text('• $a'),
+            )),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create Progress screen as a standalone page
- expose Progress via bottom navigation
- update README

## Testing
- `dart`/`flutter` not available so no formatting or tests run