### PR TITLE
Fix local data removal refresh

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -15,6 +15,15 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   int _selectedIndex = 0;
+  Key _flightScreenKey = UniqueKey();
+  Key _statusScreenKey = UniqueKey();
+
+  void _handleDataCleared() {
+    setState(() {
+      _flightScreenKey = UniqueKey();
+      _statusScreenKey = UniqueKey();
+    });
+  }
 
   void _openSettings() {
     Navigator.of(context).push(
@@ -22,6 +31,7 @@ class _HomeScreenState extends State<HomeScreen> {
         builder: (_) => SettingsScreen(
           darkMode: widget.darkMode,
           onToggleTheme: widget.onToggleTheme,
+          onClearData: _handleDataCleared,
         ),
       ),
     );
@@ -36,8 +46,8 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final pages = [
-      FlightScreen(onOpenSettings: _openSettings),
-      StatusScreen(onOpenSettings: _openSettings),
+      FlightScreen(key: _flightScreenKey, onOpenSettings: _openSettings),
+      StatusScreen(key: _statusScreenKey, onOpenSettings: _openSettings),
     ];
 
     return Scaffold(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,11 +4,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 class SettingsScreen extends StatefulWidget {
   final bool darkMode;
   final VoidCallback onToggleTheme;
+  final VoidCallback? onClearData;
 
   const SettingsScreen({
     super.key,
     required this.darkMode,
     required this.onToggleTheme,
+    this.onClearData,
   });
 
   @override
@@ -21,6 +23,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _clearData() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
+    widget.onClearData?.call();
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Local data cleared')),


### PR DESCRIPTION
## Summary
- ensure settings can notify other screens when local data is cleared
- rebuild flight and status pages after removing data

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*