### PR TITLE
Propagate flight changes across screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'models/flight.dart';
+import 'models/flight_storage.dart';
 import 'screens/home_screen.dart';
 
 void main() {
@@ -14,11 +16,27 @@ class SkyBookApp extends StatefulWidget {
 
 class _SkyBookAppState extends State<SkyBookApp> {
   bool _darkMode = false;
+  final ValueNotifier<List<Flight>> _flightsNotifier = ValueNotifier<List<Flight>>([]);
 
   void _toggleTheme() {
     setState(() {
       _darkMode = !_darkMode;
     });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFlights();
+  }
+
+  Future<void> _loadFlights() async {
+    final flights = await FlightStorage.loadFlights();
+    _flightsNotifier.value = flights;
+  }
+
+  Future<void> _saveFlights() async {
+    await FlightStorage.saveFlights(_flightsNotifier.value);
   }
 
   @override
@@ -34,6 +52,8 @@ class _SkyBookAppState extends State<SkyBookApp> {
       home: HomeScreen(
         onToggleTheme: _toggleTheme,
         darkMode: _darkMode,
+        flightsNotifier: _flightsNotifier,
+        onFlightsChanged: _saveFlights,
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/flight.dart';
 import 'flight_screen.dart';
 import 'status_screen.dart';
 import 'progress_screen.dart';
@@ -8,7 +9,16 @@ import 'settings_screen.dart';
 class HomeScreen extends StatefulWidget {
   final VoidCallback onToggleTheme;
   final bool darkMode;
-  const HomeScreen({super.key, required this.onToggleTheme, required this.darkMode});
+  final ValueNotifier<List<Flight>> flightsNotifier;
+  final Future<void> Function() onFlightsChanged;
+
+  const HomeScreen({
+    super.key,
+    required this.onToggleTheme,
+    required this.darkMode,
+    required this.flightsNotifier,
+    required this.onFlightsChanged,
+  });
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -23,7 +33,9 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       _flightScreenKey = UniqueKey();
       _statusScreenKey = UniqueKey();
+      widget.flightsNotifier.value = [];
     });
+    widget.onFlightsChanged();
   }
 
   void _openSettings() {
@@ -47,9 +59,21 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final pages = [
-      FlightScreen(onOpenSettings: _openSettings),
-      ProgressScreen(onOpenSettings: _openSettings),
-      StatusScreen(onOpenSettings: _openSettings),
+      FlightScreen(
+        key: _flightScreenKey,
+        onOpenSettings: _openSettings,
+        flightsNotifier: widget.flightsNotifier,
+        onFlightsChanged: widget.onFlightsChanged,
+      ),
+      ProgressScreen(
+        onOpenSettings: _openSettings,
+        flightsNotifier: widget.flightsNotifier,
+      ),
+      StatusScreen(
+        key: _statusScreenKey,
+        onOpenSettings: _openSettings,
+        flightsNotifier: widget.flightsNotifier,
+      ),
     ];
 
     return Scaffold(

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -5,7 +5,13 @@ import '../models/flight_storage.dart';
 
 class StatusScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
-  const StatusScreen({super.key, required this.onOpenSettings});
+  final ValueNotifier<List<Flight>> flightsNotifier;
+
+  const StatusScreen({
+    super.key,
+    required this.onOpenSettings,
+    required this.flightsNotifier,
+  });
 
   @override
   State<StatusScreen> createState() => _StatusScreenState();
@@ -13,18 +19,29 @@ class StatusScreen extends StatefulWidget {
 
 class _StatusScreenState extends State<StatusScreen> {
   List<Flight> _flights = [];
+  late VoidCallback _listener;
 
   @override
   void initState() {
     super.initState();
-    refresh();
+    _flights = widget.flightsNotifier.value;
+    _listener = () {
+      setState(() {
+        _flights = widget.flightsNotifier.value;
+      });
+    };
+    widget.flightsNotifier.addListener(_listener);
+  }
+
+  @override
+  void dispose() {
+    widget.flightsNotifier.removeListener(_listener);
+    super.dispose();
   }
 
   Future<void> refresh() async {
     final flights = await FlightStorage.loadFlights();
-    setState(() {
-      _flights = flights;
-    });
+    widget.flightsNotifier.value = flights;
   }
 
   double get _totalDuration {


### PR DESCRIPTION
## Summary
- keep all flights in a shared `ValueNotifier`
- update flight list when adding/editing flights
- listen to notifier in each screen so views refresh automatically
- reload from storage when pulling to refresh

## Testing
- `dart format` *(fails: command not found)*