### PR TITLE
Add widget test using SkyBookApp

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skybook/main.dart';
+
+void main() {
+  testWidgets('SkyBookApp smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const SkyBookApp());
+    expect(find.byType(SkyBookApp), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add test/widget_test.dart using SkyBookApp instead of MyApp

## Testing
- `flutter test` *(fails: command not found)*