### PR TITLE
Fix missing Airport type import

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/flight.dart';
 import '../models/aircraft.dart';
+import '../models/airport.dart';
 import '../data/airport_data.dart';
 import '../data/aircraft_data.dart';
 


### PR DESCRIPTION
## Summary
- add missing import for `Airport` model in AddFlightScreen

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`