### PR TITLE
Add map screen with airport geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Switch between light and dark themes
 - Enable a developer section with an option to clear local data
 - Data is stored locally on the device
-- Quickly access Flights, Progress and Status using the bottom navigation bar
+- View your routes on an interactive map
+- Quickly access Flights, Map, Progress and Status using the bottom navigation bar
 
 ## Getting Started
 

--- a/lib/data/airport_data.dart
+++ b/lib/data/airport_data.dart
@@ -1,19 +1,84 @@
 import '../models/airport.dart';
 
 const List<Airport> airports = [
-  Airport(code: 'CDG', name: 'Paris Charles De Gaulle', country: 'France'),
-  Airport(code: 'LHR', name: 'London Heathrow', country: 'United Kingdom'),
-  Airport(code: 'JFK', name: 'New York John F. Kennedy', country: 'United States'),
-  Airport(code: 'LAX', name: 'Los Angeles', country: 'United States'),
-  Airport(code: 'HND', name: 'Tokyo Haneda', country: 'Japan'),
-  Airport(code: 'DXB', name: 'Dubai', country: 'United Arab Emirates'),
-  Airport(code: 'SIN', name: 'Singapore Changi', country: 'Singapore'),
-  Airport(code: 'SYD', name: 'Sydney', country: 'Australia'),
-  Airport(code: 'FRA', name: 'Frankfurt', country: 'Germany'),
-  Airport(code: 'AMS', name: 'Amsterdam Schiphol', country: 'Netherlands'),
-  Airport(code: 'MAD', name: 'Madrid Barajas', country: 'Spain'),
-  Airport(code: 'YYZ', name: 'Toronto Pearson', country: 'Canada'),
-  Airport(code: 'PEK', name: 'Beijing Capital', country: 'China'),
+  Airport(
+      code: 'CDG',
+      name: 'Paris Charles De Gaulle',
+      country: 'France',
+      latitude: 49.0097,
+      longitude: 2.5479),
+  Airport(
+      code: 'LHR',
+      name: 'London Heathrow',
+      country: 'United Kingdom',
+      latitude: 51.4700,
+      longitude: -0.4543),
+  Airport(
+      code: 'JFK',
+      name: 'New York John F. Kennedy',
+      country: 'United States',
+      latitude: 40.6413,
+      longitude: -73.7781),
+  Airport(
+      code: 'LAX',
+      name: 'Los Angeles',
+      country: 'United States',
+      latitude: 33.9416,
+      longitude: -118.4085),
+  Airport(
+      code: 'HND',
+      name: 'Tokyo Haneda',
+      country: 'Japan',
+      latitude: 35.5494,
+      longitude: 139.7798),
+  Airport(
+      code: 'DXB',
+      name: 'Dubai',
+      country: 'United Arab Emirates',
+      latitude: 25.2532,
+      longitude: 55.3657),
+  Airport(
+      code: 'SIN',
+      name: 'Singapore Changi',
+      country: 'Singapore',
+      latitude: 1.3644,
+      longitude: 103.9915),
+  Airport(
+      code: 'SYD',
+      name: 'Sydney',
+      country: 'Australia',
+      latitude: -33.9399,
+      longitude: 151.1753),
+  Airport(
+      code: 'FRA',
+      name: 'Frankfurt',
+      country: 'Germany',
+      latitude: 50.0379,
+      longitude: 8.5622),
+  Airport(
+      code: 'AMS',
+      name: 'Amsterdam Schiphol',
+      country: 'Netherlands',
+      latitude: 52.3105,
+      longitude: 4.7683),
+  Airport(
+      code: 'MAD',
+      name: 'Madrid Barajas',
+      country: 'Spain',
+      latitude: 40.4983,
+      longitude: -3.5676),
+  Airport(
+      code: 'YYZ',
+      name: 'Toronto Pearson',
+      country: 'Canada',
+      latitude: 43.6777,
+      longitude: -79.6248),
+  Airport(
+      code: 'PEK',
+      name: 'Beijing Capital',
+      country: 'China',
+      latitude: 40.0799,
+      longitude: 116.6031),
 ];
 
 final Map<String, Airport> airportByCode = {

--- a/lib/models/airport.dart
+++ b/lib/models/airport.dart
@@ -2,8 +2,16 @@ class Airport {
   final String code;
   final String name;
   final String country;
+  final double latitude;
+  final double longitude;
 
-  const Airport({required this.code, required this.name, required this.country});
+  const Airport({
+    required this.code,
+    required this.name,
+    required this.country,
+    required this.latitude,
+    required this.longitude,
+  });
 
   String get display => '$code - $name';
 }

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -106,27 +106,15 @@ class _FlightScreenState extends State<FlightScreen> {
         onPressed: _addFlight,
         child: const Icon(Icons.add),
       ),
-      body: Column(
-        children: [
-          Container(
-            height: 150,
-            color: Colors.grey.shade300,
-            alignment: Alignment.center,
-            child: const Text('Map placeholder'),
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemCount: _flights.length,
-              itemBuilder: (context, index) {
-                return FlightTile(
-                  flight: _flights[index],
-                  onEdit: () => _editFlight(index),
-                  onToggleFavorite: () => _toggleFavorite(index),
-                );
-              },
-            ),
-          ),
-        ],
+      body: ListView.builder(
+        itemCount: _flights.length,
+        itemBuilder: (context, index) {
+          return FlightTile(
+            flight: _flights[index],
+            onEdit: () => _editFlight(index),
+            onToggleFavorite: () => _toggleFavorite(index),
+          );
+        },
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/flight.dart';
 import 'flight_screen.dart';
+import 'map_screen.dart';
 import 'status_screen.dart';
 import 'progress_screen.dart';
 import 'settings_screen.dart';
@@ -65,6 +66,10 @@ class _HomeScreenState extends State<HomeScreen> {
         flightsNotifier: widget.flightsNotifier,
         onFlightsChanged: widget.onFlightsChanged,
       ),
+      MapScreen(
+        onOpenSettings: _openSettings,
+        flightsNotifier: widget.flightsNotifier,
+      ),
       ProgressScreen(
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
@@ -83,6 +88,7 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: _onItemTapped,
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.flight), label: 'Flights'),
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
           BottomNavigationBarItem(icon: Icon(Icons.trending_up), label: 'Progress'),
           BottomNavigationBarItem(icon: Icon(Icons.assessment), label: 'Status'),
         ],

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../models/flight.dart';
+import '../data/airport_data.dart';
+
+class MapScreen extends StatefulWidget {
+  final VoidCallback onOpenSettings;
+  final ValueNotifier<List<Flight>> flightsNotifier;
+
+  const MapScreen({
+    super.key,
+    required this.onOpenSettings,
+    required this.flightsNotifier,
+  });
+
+  @override
+  State<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends State<MapScreen> {
+  List<Flight> _flights = [];
+  late VoidCallback _listener;
+
+  @override
+  void initState() {
+    super.initState();
+    _flights = widget.flightsNotifier.value;
+    _listener = () {
+      setState(() {
+        _flights = widget.flightsNotifier.value;
+      });
+    };
+    widget.flightsNotifier.addListener(_listener);
+  }
+
+  @override
+  void dispose() {
+    widget.flightsNotifier.removeListener(_listener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final markers = <Marker>[];
+    final lines = <Polyline>[];
+
+    for (final f in _flights) {
+      final origin = airportByCode[f.origin];
+      final dest = airportByCode[f.destination];
+      if (origin != null && dest != null) {
+        final start = LatLng(origin.latitude, origin.longitude);
+        final end = LatLng(dest.latitude, dest.longitude);
+        markers.addAll([
+          Marker(
+            point: start,
+            width: 30,
+            height: 30,
+            builder: (_) => const Icon(Icons.flight_takeoff, color: Colors.blue),
+          ),
+          Marker(
+            point: end,
+            width: 30,
+            height: 30,
+            builder: (_) => const Icon(Icons.flight_land, color: Colors.red),
+          ),
+        ]);
+        lines.add(Polyline(points: [start, end], color: Colors.blue, strokeWidth: 2));
+      }
+    }
+
+    final center = markers.isNotEmpty ? markers.first.point : const LatLng(20, 0);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Map'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: widget.onOpenSettings,
+          ),
+        ],
+      ),
+      body: FlutterMap(
+        options: MapOptions(center: center, zoom: 2),
+        children: [
+          TileLayer(
+            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+            userAgentPackageName: 'com.example.app',
+          ),
+          PolylineLayer(polylines: lines),
+          MarkerLayer(markers: markers),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^2.2.0
+  flutter_map: ^6.1.0
+  latlong2: ^0.8.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- include `flutter_map` for simple OpenStreetMap view
- add latitude and longitude to airport data
- create a new `MapScreen` to display flights on a map
- show the Map screen in the bottom navigation
- remove old map placeholder from Flight screen
- update README features

## Testing
- `flutter pub get` *(fails: `flutter` not installed)*