### PR TITLE
Fix const constructor error in MapScreen

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -70,7 +70,7 @@ class _MapScreenState extends State<MapScreen> {
       }
     }
 
-    final center = markers.isNotEmpty ? markers.first.point : const LatLng(20, 0);
+    final center = markers.isNotEmpty ? markers.first.point : LatLng(20, 0);
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary
- remove `const` keyword when constructing `LatLng` in MapScreen

## Testing
- `flutter --version` *(fails: command not found)*