### PR TITLE
Add zoom controls and persist map state

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -67,6 +67,7 @@ class _HomeScreenState extends State<HomeScreen> {
         onFlightsChanged: widget.onFlightsChanged,
       ),
       MapScreen(
+        key: const PageStorageKey('map'),
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
       ),


### PR DESCRIPTION
## Summary
- keep `MapScreen` state alive with a key
- persist map position and zoom with `MapController`
- add zoom in/out floating buttons

## Testing
- `dart analyze` *(fails: command not found)*