### PR TITLE
Set map as home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Enable a developer section with an option to clear local data
 - Data is stored locally on the device
 - View your routes on an interactive map
-- Quickly access Flights, Map, Progress and Status using the bottom navigation bar
+- Quickly access Map, Flights, Progress and Status using the bottom navigation bar
 
 ## Getting Started
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -60,16 +60,16 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final pages = [
+      MapScreen(
+        key: const PageStorageKey('map'),
+        onOpenSettings: _openSettings,
+        flightsNotifier: widget.flightsNotifier,
+      ),
       FlightScreen(
         key: _flightScreenKey,
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
         onFlightsChanged: widget.onFlightsChanged,
-      ),
-      MapScreen(
-        key: const PageStorageKey('map'),
-        onOpenSettings: _openSettings,
-        flightsNotifier: widget.flightsNotifier,
       ),
       ProgressScreen(
         onOpenSettings: _openSettings,
@@ -91,8 +91,8 @@ class _HomeScreenState extends State<HomeScreen> {
         unselectedItemColor:
             Theme.of(context).colorScheme.onSurfaceVariant,
         items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.flight), label: 'Flights'),
           BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+          BottomNavigationBarItem(icon: Icon(Icons.flight), label: 'Flights'),
           BottomNavigationBarItem(icon: Icon(Icons.trending_up), label: 'Progress'),
           BottomNavigationBarItem(icon: Icon(Icons.assessment), label: 'Status'),
         ],


### PR DESCRIPTION
## Summary
- make Map the default page
- reorder navigation items to `Map`, `Flights`, `Progress`, `Status`
- update README to mention new order

## Testing
- `flutter --version` *(fails: command not found)*