### PR TITLE
Fix Flights button alignment

### DIFF
--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -102,6 +102,8 @@ class _FlightScreenState extends State<FlightScreen> {
           ),
         ],
       ),
+      floatingActionButtonLocation:
+          FloatingActionButtonLocation.centerFloat,
       floatingActionButton: FloatingActionButton(
         onPressed: _addFlight,
         child: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- position add flight button in the center

## Testing
- `flutter --version` *(fails: command not found)*