### PR TITLE
Add seat details to flights

### DIFF
--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -7,6 +7,9 @@ class Flight {
   final String notes;
   final String origin;
   final String destination;
+  final String travelClass;
+  final String seatNumber;
+  final String seatLocation;
   final bool isFavorite;
 
   Flight({
@@ -18,6 +21,9 @@ class Flight {
     required this.notes,
     required this.origin,
     required this.destination,
+    required this.travelClass,
+    required this.seatNumber,
+    required this.seatLocation,
     this.isFavorite = false,
   });
 
@@ -31,6 +37,9 @@ class Flight {
       'notes': notes,
       'origin': origin,
       'destination': destination,
+      'travelClass': travelClass,
+      'seatNumber': seatNumber,
+      'seatLocation': seatLocation,
       'isFavorite': isFavorite,
     };
   }
@@ -45,6 +54,9 @@ class Flight {
       notes: map['notes'] as String? ?? '',
       origin: map['origin'] as String? ?? '',
       destination: map['destination'] as String? ?? '',
+      travelClass: map['travelClass'] as String? ?? '',
+      seatNumber: map['seatNumber'] as String? ?? '',
+      seatLocation: map['seatLocation'] as String? ?? '',
       isFavorite: map['isFavorite'] as bool? ?? false,
     );
   }

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -21,6 +21,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   final _originController = TextEditingController();
   final _destinationController = TextEditingController();
   final _aircraftController = TextEditingController();
+  final _seatNumberController = TextEditingController();
+  String _travelClass = 'Economy';
+  String _seatLocation = 'Window';
 
   Aircraft? _selectedAircraft;
 
@@ -36,6 +39,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       _notesController.text = flight.notes;
       _originController.text = flight.origin;
       _destinationController.text = flight.destination;
+      _travelClass = flight.travelClass.isNotEmpty ? flight.travelClass : 'Economy';
+      _seatNumberController.text = flight.seatNumber;
+      _seatLocation = flight.seatLocation.isNotEmpty ? flight.seatLocation : 'Window';
     } else {
       _selectedAircraft = aircrafts.first;
       _aircraftController.text = _selectedAircraft!.display;
@@ -75,6 +81,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       notes: _notesController.text,
       origin: _originController.text,
       destination: _destinationController.text,
+      travelClass: _travelClass,
+      seatNumber: _seatNumberController.text,
+      seatLocation: _seatLocation,
       isFavorite: widget.flight?.isFavorite ?? false,
     );
     Navigator.of(context).pop(flight);
@@ -191,6 +200,43 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
               controller: _durationController,
               keyboardType: TextInputType.number,
               decoration: const InputDecoration(labelText: 'Duration (hrs)'),
+            ),
+            DropdownButtonFormField<String>(
+              value: _travelClass,
+              decoration: const InputDecoration(labelText: 'Class'),
+              items: const [
+                DropdownMenuItem(value: 'Economy', child: Text('Economy')),
+                DropdownMenuItem(value: 'Premium', child: Text('Premium')),
+                DropdownMenuItem(value: 'Business', child: Text('Business')),
+                DropdownMenuItem(value: 'First', child: Text('First')),
+              ],
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() {
+                    _travelClass = value;
+                  });
+                }
+              },
+            ),
+            TextField(
+              controller: _seatNumberController,
+              decoration: const InputDecoration(labelText: 'Seat Number'),
+            ),
+            DropdownButtonFormField<String>(
+              value: _seatLocation,
+              decoration: const InputDecoration(labelText: 'Seat Location'),
+              items: const [
+                DropdownMenuItem(value: 'Window', child: Text('Window')),
+                DropdownMenuItem(value: 'Middle', child: Text('Middle')),
+                DropdownMenuItem(value: 'Aisle', child: Text('Aisle')),
+              ],
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() {
+                    _seatLocation = value;
+                  });
+                }
+              },
             ),
             TextField(
               controller: _notesController,

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -84,6 +84,9 @@ class _FlightScreenState extends State<FlightScreen> {
       destination: flight.destination,
       duration: flight.duration,
       notes: flight.notes,
+      travelClass: flight.travelClass,
+      seatNumber: flight.seatNumber,
+      seatLocation: flight.seatLocation,
       isFavorite: !flight.isFavorite,
     );
     widget.flightsNotifier.value = list;

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -52,6 +52,21 @@ class FlightTile extends StatelessWidget {
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
             ),
+            if (flight.travelClass.isNotEmpty ||
+                flight.seatNumber.isNotEmpty ||
+                flight.seatLocation.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Center(
+                child: Text(
+                  [
+                    flight.travelClass,
+                    flight.seatNumber,
+                    flight.seatLocation
+                  ].where((e) => e.isNotEmpty).join(' • '),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            ],
             if (notes.isNotEmpty) ...[
               const SizedBox(height: 4),
               Text(notes),


### PR DESCRIPTION
## Summary
- add travel class, seat number and seat location fields to `Flight`
- allow editing/adding these fields when creating or editing flights
- persist seat fields when toggling favourite
- display seat details in flight list tiles
- use dropdown with Economy, Premium, Business and First options for class

## Testing
- `dart format lib/models/flight.dart lib/screens/add_flight_screen.dart lib/widgets/flight_tile.dart lib/screens/flight_screen.dart > /tmp/format.log && tail -n 20 /tmp/format.log` (failed to run: `dart: command not found`)
- `flutter --version` (failed to run: `flutter: command not found`)
