### PR TITLE
Add flight number input with automatic airline detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 ## Features
 
 - Add flights with date, aircraft, duration and optional notes
-- Select the airline from a list when adding flights
+- Enter the flight number and the airline will be detected automatically
 - View a list of all recorded flights
 - View overall stats like total flights and hours
+- See your top airlines in the Status section
 - Track progress with detailed achievements for flight counts, distance and destinations
 - Switch between light and dark themes
 - Enable a developer section with an option to clear local data

--- a/lib/data/airline_data.dart
+++ b/lib/data/airline_data.dart
@@ -1,16 +1,20 @@
 import '../models/airline.dart';
 
 const List<Airline> airlines = [
-  Airline(name: 'Air France', callsign: 'AFR'),
-  Airline(name: 'British Airways', callsign: 'BAW'),
-  Airline(name: 'Emirates', callsign: 'UAE'),
-  Airline(name: 'Lufthansa', callsign: 'DLH'),
-  Airline(name: 'Delta Air Lines', callsign: 'DAL'),
-  Airline(name: 'American Airlines', callsign: 'AAL'),
-  Airline(name: 'United Airlines', callsign: 'UAL'),
-  Airline(name: 'Qantas', callsign: 'QFA'),
+  Airline(name: 'Air France', callsign: 'AFR', code: 'AF'),
+  Airline(name: 'British Airways', callsign: 'BAW', code: 'BA'),
+  Airline(name: 'Emirates', callsign: 'UAE', code: 'EK'),
+  Airline(name: 'Lufthansa', callsign: 'DLH', code: 'LH'),
+  Airline(name: 'Delta Air Lines', callsign: 'DAL', code: 'DL'),
+  Airline(name: 'American Airlines', callsign: 'AAL', code: 'AA'),
+  Airline(name: 'United Airlines', callsign: 'UAL', code: 'UA'),
+  Airline(name: 'Qantas', callsign: 'QFA', code: 'QF'),
 ];
 
 final Map<String, Airline> airlineByName = {
   for (final a in airlines) a.name: a,
+};
+
+final Map<String, Airline> airlineByCode = {
+  for (final a in airlines) a.code: a,
 };

--- a/lib/models/airline.dart
+++ b/lib/models/airline.dart
@@ -1,8 +1,9 @@
 class Airline {
   final String name;
   final String callsign;
+  final String code;
 
-  const Airline({required this.name, required this.callsign});
+  const Airline({required this.name, required this.callsign, required this.code});
 
   String get display => name;
 }

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -69,6 +69,22 @@ class _StatusScreenState extends State<StatusScreen> {
     return entries.take(3).toList();
   }
 
+  Map<String, int> get _airlineCount {
+    final counts = <String, int>{};
+    for (final f in _flights) {
+      if (f.airline.isNotEmpty) {
+        counts[f.airline] = (counts[f.airline] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+
+  List<MapEntry<String, int>> get _topAirlines {
+    final entries = _airlineCount.entries.toList();
+    entries.sort((a, b) => b.value.compareTo(a.value));
+    return entries.take(3).toList();
+  }
+
   Map<String, int> get _countryCount {
     final counts = <String, int>{};
     for (final f in _flights) {
@@ -126,6 +142,8 @@ class _StatusScreenState extends State<StatusScreen> {
             const SizedBox(height: 24),
             _buildAircraftChart(),
             const SizedBox(height: 24),
+            _buildAirlineChart(),
+            const SizedBox(height: 24),
             _buildCountryChart(),
           ],
         ),
@@ -145,6 +163,54 @@ class _StatusScreenState extends State<StatusScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text('Top Aircraft',
+            style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ...top.map((e) {
+          final barWidth = e.value / maxCount;
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              children: [
+                SizedBox(width: 100, child: Text(e.key)),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      Container(
+                        height: 20,
+                        color: Colors.grey.shade300,
+                      ),
+                      FractionallySizedBox(
+                        widthFactor: barWidth,
+                        child: Container(
+                          height: 20,
+                          color: Colors.blue,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(e.value.toString()),
+              ],
+            ),
+          );
+        })
+      ],
+    );
+  }
+
+  Widget _buildAirlineChart() {
+    if (_flights.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final top = _topAirlines;
+    final maxCount = top.isNotEmpty ? top.first.value : 1;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Top Airlines',
             style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 8),
         ...top.map((e) {


### PR DESCRIPTION
## Summary
- allow entering flight number instead of selecting airline
- infer airline from the first two characters of the flight number
- show top airlines on the Status screen
- document automatic airline detection in README

## Testing
- `dart format -l 120 lib README.md` *(fails: `dart` not found)*
- `flutter --version` *(fails: `flutter` not found)*