### PR TITLE
Persist theme preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - See your top airlines in the Status section
 - Track progress with detailed achievements for flight counts, distance and destinations
 - Switch between light and dark themes
+- Theme preference is saved so your choice is remembered
 - Enable a developer section with an option to clear local data
 - Data is stored locally on the device
 - View your routes on an interactive map

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'models/flight.dart';
 import 'models/flight_storage.dart';
+import 'models/theme_storage.dart';
 import 'screens/home_screen.dart';
 
 void main() {
@@ -22,12 +23,14 @@ class _SkyBookAppState extends State<SkyBookApp> {
     setState(() {
       _darkMode = !_darkMode;
     });
+    ThemeStorage.saveDarkMode(_darkMode);
   }
 
   @override
   void initState() {
     super.initState();
     _loadFlights();
+    _loadTheme();
   }
 
   Future<void> _loadFlights() async {
@@ -37,6 +40,15 @@ class _SkyBookAppState extends State<SkyBookApp> {
 
   Future<void> _saveFlights() async {
     await FlightStorage.saveFlights(_flightsNotifier.value);
+  }
+
+  Future<void> _loadTheme() async {
+    final saved = await ThemeStorage.loadDarkMode();
+    if (mounted) {
+      setState(() {
+        _darkMode = saved;
+      });
+    }
   }
 
   @override

--- a/lib/models/theme_storage.dart
+++ b/lib/models/theme_storage.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeStorage {
+  static const String _key = 'darkMode';
+
+  static Future<bool> loadDarkMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? false;
+  }
+
+  static Future<void> saveDarkMode(bool darkMode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, darkMode);
+  }
+}


### PR DESCRIPTION
## Summary
- save and restore theme preference with ThemeStorage
- document new theme persistence feature

## Testing
- `dart --version` *(fails: command not found)*