### PR TITLE
Use image assets for bottom nav icons

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -90,11 +90,23 @@ class _HomeScreenState extends State<HomeScreen> {
         selectedItemColor: Theme.of(context).colorScheme.primary,
         unselectedItemColor:
             Theme.of(context).colorScheme.onSurfaceVariant,
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
-          BottomNavigationBarItem(icon: Icon(Icons.flight), label: 'Flights'),
-          BottomNavigationBarItem(icon: Icon(Icons.trending_up), label: 'Progress'),
-          BottomNavigationBarItem(icon: Icon(Icons.assessment), label: 'Status'),
+        items: [
+          BottomNavigationBarItem(
+            icon: ImageIcon(const AssetImage('assets/icons/map.png')),
+            label: 'Map',
+          ),
+          BottomNavigationBarItem(
+            icon: ImageIcon(const AssetImage('assets/icons/flights.png')),
+            label: 'Flights',
+          ),
+          BottomNavigationBarItem(
+            icon: ImageIcon(const AssetImage('assets/icons/progress.png')),
+            label: 'Progress',
+          ),
+          BottomNavigationBarItem(
+            icon: ImageIcon(const AssetImage('assets/icons/status.png')),
+            label: 'Status',
+          ),
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/icons/


### PR DESCRIPTION
## Summary
- remove png icons and register directory for future assets
- add placeholder `.gitkeep` to keep folder structure
- update bottom nav icons to use asset images

## Testing
- `git status --short`
