### PR TITLE
Replace snackbar with achievement dialog

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'models/theme_storage.dart';
 import 'models/achievement.dart';
 import 'utils/achievement_utils.dart';
 import 'screens/home_screen.dart';
+import 'widgets/achievement_dialog.dart';
 
 const Color _brandPrimary = Color(0xFF0A73B1);
 const Color _brandSecondary = Color(0xFFEF6C00);
@@ -40,9 +41,13 @@ class _SkyBookAppState extends State<SkyBookApp> {
     for (final a in newAchievements) {
       if (a.achieved && !_unlockedAchievements.contains(a.id)) {
         _unlockedAchievements.add(a.id);
-        _messengerKey.currentState?.showSnackBar(
-          SnackBar(content: Text('Achievement unlocked: ${a.title}')),
-        );
+        final context = _messengerKey.currentContext;
+        if (context != null) {
+          showDialog(
+            context: context,
+            builder: (_) => AchievementDialog(title: a.title),
+          );
+        }
       }
     }
   }

--- a/lib/widgets/achievement_dialog.dart
+++ b/lib/widgets/achievement_dialog.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class AchievementDialog extends StatefulWidget {
+  final String title;
+  const AchievementDialog({super.key, required this.title});
+
+  @override
+  State<AchievementDialog> createState() => _AchievementDialogState();
+}
+
+class _AchievementDialogState extends State<AchievementDialog>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 600),
+  )..forward();
+  late final Animation<double> _animation =
+      CurvedAnimation(parent: _controller, curve: Curves.elasticOut);
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Achievement Unlocked!'),
+      content: Row(
+        children: [
+          ScaleTransition(
+            scale: _animation,
+            child: Icon(
+              Icons.emoji_events,
+              color: Theme.of(context).colorScheme.secondary,
+              size: 48,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              widget.title,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an `AchievementDialog` with a simple scale animation
- show the dialog in `_updateAchievements` when achievements unlock

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*