### PR TITLE
Add achievement unlock timestamps

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -6,6 +6,7 @@ class Achievement {
   final int target;
   final int progress;
   final bool achieved;
+  final DateTime? unlockedAt;
 
   const Achievement({
     required this.id,
@@ -15,6 +16,7 @@ class Achievement {
     required this.target,
     required this.progress,
     required this.achieved,
+    this.unlockedAt,
   });
 }
 

--- a/lib/models/achievement_storage.dart
+++ b/lib/models/achievement_storage.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AchievementStorage {
+  static const String _key = 'achievements';
+
+  static Future<Map<String, DateTime>> loadUnlocked() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_key);
+    if (stored == null) return {};
+    final Map<String, dynamic> decoded = json.decode(stored);
+    final result = <String, DateTime>{};
+    for (final entry in decoded.entries) {
+      final time = DateTime.tryParse(entry.value as String? ?? '');
+      if (time != null) result[entry.key] = time;
+    }
+    return result;
+  }
+
+  static Future<void> saveUnlocked(String id, DateTime time) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = await loadUnlocked();
+    current[id] = time;
+    final encoded = json.encode(
+        current.map((key, value) => MapEntry(key, value.toIso8601String())));
+    await prefs.setString(_key, encoded);
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,6 +12,7 @@ class HomeScreen extends StatefulWidget {
   final bool darkMode;
   final ValueNotifier<List<Flight>> flightsNotifier;
   final Future<void> Function() onFlightsChanged;
+  final Map<String, DateTime> unlockedAchievements;
 
   const HomeScreen({
     super.key,
@@ -19,6 +20,7 @@ class HomeScreen extends StatefulWidget {
     required this.darkMode,
     required this.flightsNotifier,
     required this.onFlightsChanged,
+    required this.unlockedAchievements,
   });
 
   @override
@@ -74,6 +76,7 @@ class _HomeScreenState extends State<HomeScreen> {
       ProgressScreen(
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
+        unlockedAchievements: widget.unlockedAchievements,
       ),
       StatusScreen(
         key: _statusScreenKey,

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -4,16 +4,19 @@ import '../models/flight.dart';
 import '../models/flight_storage.dart';
 import '../models/achievement.dart';
 import '../utils/achievement_utils.dart';
+import 'package:intl/intl.dart';
 import '../widgets/skybook_app_bar.dart';
 
 class ProgressScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
   final ValueNotifier<List<Flight>> flightsNotifier;
+  final Map<String, DateTime> unlockedAchievements;
 
   const ProgressScreen({
     super.key,
     required this.onOpenSettings,
     required this.flightsNotifier,
+    required this.unlockedAchievements,
   });
 
   @override
@@ -96,7 +99,8 @@ class _ProgressScreenState extends State<ProgressScreen>
       return const SizedBox.shrink();
     }
 
-    final achievements = calculateAchievements(_flights);
+    final achievements =
+        calculateAchievements(_flights, widget.unlockedAchievements);
     final selected = _categories[_tabController.index];
     final filtered = achievements
         .where((a) => selected == 'All' || a.category == selected)
@@ -137,6 +141,11 @@ class _ProgressScreenState extends State<ProgressScreen>
                       children: [
                         Text(a.title,
                             style: Theme.of(context).textTheme.bodyMedium),
+                        if (a.unlockedAt != null)
+                          Text(
+                            DateFormat.yMMMd().format(a.unlockedAt!),
+                            style: Theme.of(context).textTheme.labelSmall,
+                          ),
                         const SizedBox(height: 2),
                         Semantics(
                           label:

--- a/lib/utils/achievement_utils.dart
+++ b/lib/utils/achievement_utils.dart
@@ -11,7 +11,7 @@ Achievement _progress(
   String category,
   int current,
   int target,
-) {
+  {DateTime? unlockedAt}) {
   return Achievement(
     id: id,
     title: title,
@@ -20,10 +20,12 @@ Achievement _progress(
     target: target,
     progress: current.clamp(0, target),
     achieved: current >= target,
+    unlockedAt: unlockedAt,
   );
 }
 
-List<Achievement> calculateAchievements(List<Flight> flights) {
+List<Achievement> calculateAchievements(List<Flight> flights,
+    [Map<String, DateTime> unlocked = const {}]) {
   final distance = const Distance();
   final totalFlights = flights.length;
 
@@ -50,13 +52,29 @@ List<Achievement> calculateAchievements(List<Flight> flights) {
   }
 
   return [
-    _progress('firstFlight', 'First Flight', 'Log 1 flight', 'Flights', totalFlights, 1),
-    _progress('frequentFlyer', 'Frequent Flyer', 'Log 50 flights', 'Flights', totalFlights, 50),
-    _progress('globeTrotter', 'Globe Trotter', 'Log 100 flights', 'Flights', totalFlights, 100),
-    _progress('shortHaul', 'Short Haul Hero', 'Travel 1,000 km', 'Distance', totalKm.round(), 1000),
-    _progress('aroundWorld', 'Around the World', 'Travel 40,075 km', 'Distance', totalKm.round(), 40075),
-    _progress('longHaul', 'Long Haul Legend', 'Travel 100,000 km', 'Distance', totalKm.round(), 100000),
-    _progress('newHorizons', 'New Horizons', 'Visit 5 different countries', 'Destinations', countriesVisited.length, 5),
-    _progress('airportAddict', 'Airport Addict', 'Land at 50 different airports', 'Destinations', airportsVisited.length, 50),
+    _progress('firstFlight', 'First Flight', 'Log 1 flight', 'Flights',
+        totalFlights, 1,
+        unlockedAt: unlocked['firstFlight']),
+    _progress('frequentFlyer', 'Frequent Flyer', 'Log 50 flights', 'Flights',
+        totalFlights, 50,
+        unlockedAt: unlocked['frequentFlyer']),
+    _progress('globeTrotter', 'Globe Trotter', 'Log 100 flights', 'Flights',
+        totalFlights, 100,
+        unlockedAt: unlocked['globeTrotter']),
+    _progress('shortHaul', 'Short Haul Hero', 'Travel 1,000 km', 'Distance',
+        totalKm.round(), 1000,
+        unlockedAt: unlocked['shortHaul']),
+    _progress('aroundWorld', 'Around the World', 'Travel 40,075 km', 'Distance',
+        totalKm.round(), 40075,
+        unlockedAt: unlocked['aroundWorld']),
+    _progress('longHaul', 'Long Haul Legend', 'Travel 100,000 km', 'Distance',
+        totalKm.round(), 100000,
+        unlockedAt: unlocked['longHaul']),
+    _progress('newHorizons', 'New Horizons', 'Visit 5 different countries',
+        'Destinations', countriesVisited.length, 5,
+        unlockedAt: unlocked['newHorizons']),
+    _progress('airportAddict', 'Airport Addict', 'Land at 50 different airports',
+        'Destinations', airportsVisited.length, 50,
+        unlockedAt: unlocked['airportAddict']),
   ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   latlong2: ^0.8.1
   # google_fonts: ^5.1.0
   google_fonts: ^4.0.4
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- track when each achievement was unlocked
- persist unlocked achievement timestamps
- pass unlock data into achievement calculations
- show unlock dates on progress screen
- add `intl` dependency for date formatting

## Testing
- `git status --short`