### PR TITLE
Fix dropdown not closing on selection

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -199,7 +199,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                   final Airport option = options.elementAt(index);
                   return ListTile(
                     title: Text(option.display),
-                    onTap: () => onSelected(option),
+                    onTap: () {
+                      onSelected(option);
+                      focusNode.unfocus();
+                    },
                   );
                 },
               ),
@@ -254,7 +257,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                   final Aircraft option = options.elementAt(index);
                   return ListTile(
                     title: Text(option.display),
-                    onTap: () => onSelected(option),
+                    onTap: () {
+                      onSelected(option);
+                      _aircraftFocusNode.unfocus();
+                    },
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- ensure RawAutocomplete suggestions close when an item is tapped

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`