### PR TITLE
Use material icons on home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -95,19 +95,23 @@ class _HomeScreenState extends State<HomeScreen> {
             Theme.of(context).colorScheme.onSurfaceVariant,
         items: [
           BottomNavigationBarItem(
-            icon: ImageIcon(const AssetImage('assets/icons/map.png')),
+            // icon: ImageIcon(const AssetImage('assets/icons/map.png')),
+            icon: const Icon(Icons.map),
             label: 'Map',
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(const AssetImage('assets/icons/flights.png')),
+            // icon: ImageIcon(const AssetImage('assets/icons/flights.png')),
+            icon: const Icon(Icons.flight),
             label: 'Flights',
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(const AssetImage('assets/icons/progress.png')),
+            // icon: ImageIcon(const AssetImage('assets/icons/progress.png')),
+            icon: const Icon(Icons.emoji_events),
             label: 'Progress',
           ),
           BottomNavigationBarItem(
-            icon: ImageIcon(const AssetImage('assets/icons/status.png')),
+            // icon: ImageIcon(const AssetImage('assets/icons/status.png')),
+            icon: const Icon(Icons.analytics),
             label: 'Status',
           ),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - assets/icons/
+    # - assets/icons/
     - assets/logo.png


### PR DESCRIPTION
## Summary
- disable custom icon assets in `pubspec.yaml`
- switch bottom navigation icons to material icons

## Testing
- `flutter --version` *(fails: command not found)*