### PR TITLE
Organize aircraft data

### DIFF
--- a/lib/data/aircraft_data.dart
+++ b/lib/data/aircraft_data.dart
@@ -1,16 +1,30 @@
 import '../models/aircraft.dart';
 
+/// List of common aircraft grouped by manufacturer.
 const List<Aircraft> aircrafts = [
+  // Airbus
   Aircraft(manufacturer: 'Airbus', model: 'A320'),
   Aircraft(manufacturer: 'Airbus', model: 'A321'),
   Aircraft(manufacturer: 'Airbus', model: 'A330'),
   Aircraft(manufacturer: 'Airbus', model: 'A350'),
+
+  // Boeing
   Aircraft(manufacturer: 'Boeing', model: '737'),
   Aircraft(manufacturer: 'Boeing', model: '747'),
   Aircraft(manufacturer: 'Boeing', model: '757'),
   Aircraft(manufacturer: 'Boeing', model: '767'),
   Aircraft(manufacturer: 'Boeing', model: '777'),
   Aircraft(manufacturer: 'Boeing', model: '787'),
+
+  // Embraer
+  Aircraft(manufacturer: 'Embraer', model: 'E170'),
+  Aircraft(manufacturer: 'Embraer', model: 'E190'),
+  Aircraft(manufacturer: 'Embraer', model: 'E195'),
+
+  // Private jets
+  Aircraft(manufacturer: 'Gulfstream', model: 'G650'),
+  Aircraft(manufacturer: 'Cessna', model: 'Citation X'),
+  Aircraft(manufacturer: 'Bombardier', model: 'Global 7500'),
 ];
 
 final Map<String, Aircraft> aircraftByDisplay = {


### PR DESCRIPTION
## Summary
- organize `aircraft_data.dart` by manufacturer
- add Embraer and several private jet aircraft entries

## Testing
- `dart format lib/data/aircraft_data.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*