### PR TITLE
Persist developer mode setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Switch between light and dark themes
 - Theme preference is saved so your choice is remembered
 - Enable a developer section with an option to clear local data
+- Developer section preference is saved so your choice is remembered
 - Data is stored locally on the device
 - View your routes on an interactive map
 - Quickly access Map, Flights, Progress and Status using the bottom navigation bar

--- a/lib/models/developer_storage.dart
+++ b/lib/models/developer_storage.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DeveloperStorage {
+  static const String _key = 'developerMode';
+
+  static Future<bool> loadDeveloperMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? false;
+  }
+
+  static Future<void> saveDeveloperMode(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, enabled);
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/skybook_app_bar.dart';
+import '../models/developer_storage.dart';
 
 class SettingsScreen extends StatefulWidget {
   final bool darkMode;
@@ -20,6 +21,21 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _developerMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDeveloperMode();
+  }
+
+  Future<void> _loadDeveloperMode() async {
+    final saved = await DeveloperStorage.loadDeveloperMode();
+    if (mounted) {
+      setState(() {
+        _developerMode = saved;
+      });
+    }
+  }
 
   Future<void> _clearData() async {
     widget.onClearData?.call();
@@ -50,6 +66,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               setState(() {
                 _developerMode = val;
               });
+              DeveloperStorage.saveDeveloperMode(val);
             },
           ),
           if (_developerMode)


### PR DESCRIPTION
## Summary
- add `DeveloperStorage` for saving developer mode preference
- load and save developer mode value in `SettingsScreen`
- mention persistence of developer section in README

## Testing
- `dart format lib/models/developer_storage.dart lib/screens/settings_screen.dart README.md` *(fails: `dart` not found)*