### PR TITLE
Persist flight distance

### DIFF
--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -12,6 +12,7 @@ class Flight {
   final String travelClass;
   final String seatNumber;
   final String seatLocation;
+  final double distanceKm;
   final bool isFavorite;
 
   Flight({
@@ -28,6 +29,7 @@ class Flight {
     required this.travelClass,
     required this.seatNumber,
     required this.seatLocation,
+    this.distanceKm = 0,
     this.isFavorite = false,
   });
 
@@ -46,6 +48,7 @@ class Flight {
       'travelClass': travelClass,
       'seatNumber': seatNumber,
       'seatLocation': seatLocation,
+      'distanceKm': distanceKm,
       'isFavorite': isFavorite,
     };
   }
@@ -65,6 +68,7 @@ class Flight {
       travelClass: map['travelClass'] as String? ?? '',
       seatNumber: map['seatNumber'] as String? ?? '',
       seatLocation: map['seatLocation'] as String? ?? '',
+      distanceKm: (map['distanceKm'] as num?)?.toDouble() ?? 0,
       isFavorite: map['isFavorite'] as bool? ?? false,
     );
   }

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -150,6 +150,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       travelClass: _travelClass,
       seatNumber: _seatNumberController.text,
       seatLocation: _seatLocation,
+      distanceKm: _distanceKm ?? widget.flight?.distanceKm ?? 0,
       isFavorite: widget.flight?.isFavorite ?? false,
     );
     Navigator.of(context).pop(flight);

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -42,6 +42,9 @@ class FlightDetailScreen extends StatelessWidget {
     if (flight.duration.isNotEmpty) {
       items.add(_tile('Duration', '${flight.duration}h'));
     }
+    if (flight.distanceKm > 0) {
+      items.add(_tile('Distance', '${flight.distanceKm.round()} km'));
+    }
     if (flight.travelClass.isNotEmpty) {
       items.add(_tile('Class', flight.travelClass));
     }

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -91,6 +91,7 @@ class _FlightScreenState extends State<FlightScreen> {
       travelClass: flight.travelClass,
       seatNumber: flight.seatNumber,
       seatLocation: flight.seatLocation,
+      distanceKm: flight.distanceKm,
       isFavorite: !flight.isFavorite,
     );
     widget.flightsNotifier.value = list;

--- a/lib/utils/achievement_utils.dart
+++ b/lib/utils/achievement_utils.dart
@@ -26,9 +26,8 @@ Achievement _progress(
 
 List<Achievement> calculateAchievements(List<Flight> flights,
     [Map<String, DateTime> unlocked = const {}]) {
-  final distance = const Distance();
   final totalFlights = flights.length;
-
+  final distance = const Distance();
   double totalKm = 0;
   final airportsVisited = <String>{};
   final countriesVisited = <String>{};
@@ -44,7 +43,9 @@ List<Achievement> calculateAchievements(List<Flight> flights,
       airportsVisited.add(dest.code);
       countriesVisited.add(dest.country);
     }
-    if (origin != null && dest != null) {
+    if (f.distanceKm > 0) {
+      totalKm += f.distanceKm;
+    } else if (origin != null && dest != null) {
       final start = LatLng(origin.latitude, origin.longitude);
       final end = LatLng(dest.latitude, dest.longitude);
       totalKm += distance.as(LengthUnit.Kilometer, start, end);


### PR DESCRIPTION
## Summary
- persist distance with each flight
- display stored distance in flight details
- keep distance value when toggling favorite
- use stored distance for achievement calculations

## Testing
- `dart format` *(fails: command not found)*