### PR TITLE
Add carbon emission estimation

### DIFF
--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -13,6 +13,7 @@ class Flight {
   final String seatNumber;
   final String seatLocation;
   final double distanceKm;
+  final double carbonKg;
   final bool isFavorite;
 
   Flight({
@@ -30,6 +31,7 @@ class Flight {
     required this.seatNumber,
     required this.seatLocation,
     this.distanceKm = 0,
+    this.carbonKg = 0,
     this.isFavorite = false,
   });
 
@@ -49,6 +51,7 @@ class Flight {
       'seatNumber': seatNumber,
       'seatLocation': seatLocation,
       'distanceKm': distanceKm,
+      'carbonKg': carbonKg,
       'isFavorite': isFavorite,
     };
   }
@@ -69,6 +72,7 @@ class Flight {
       seatNumber: map['seatNumber'] as String? ?? '',
       seatLocation: map['seatLocation'] as String? ?? '',
       distanceKm: (map['distanceKm'] as num?)?.toDouble() ?? 0,
+      carbonKg: (map['carbonKg'] as num?)?.toDouble() ?? 0,
       isFavorite: map['isFavorite'] as bool? ?? false,
     );
   }

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -12,6 +12,7 @@ import '../data/aircraft_data.dart';
 import '../data/airline_data.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../utils/text_formatters.dart';
+import '../utils/carbon_utils.dart';
 
 class AddFlightScreen extends StatefulWidget {
   final Flight? flight;
@@ -39,6 +40,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   String _seatLocation = 'Window';
 
   double? _distanceKm;
+  double? _carbonKg;
 
   LatLng? _originLatLng;
   LatLng? _destinationLatLng;
@@ -59,12 +61,18 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
           LatLng(dest.latitude, dest.longitude));
       setState(() {
         _distanceKm = km;
+        _carbonKg = estimateEmissions(
+          km,
+          _selectedAircraft?.display ?? _aircraftController.text,
+          _travelClass,
+        );
         _originLatLng = LatLng(origin.latitude, origin.longitude);
         _destinationLatLng = LatLng(dest.latitude, dest.longitude);
       });
     } else {
       setState(() {
         _distanceKm = null;
+        _carbonKg = null;
         _originLatLng = null;
         _destinationLatLng = null;
       });
@@ -135,6 +143,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       _travelClass = flight.travelClass.isNotEmpty ? flight.travelClass : 'Economy';
       _seatNumberController.text = flight.seatNumber;
       _seatLocation = flight.seatLocation.isNotEmpty ? flight.seatLocation : 'Window';
+      _carbonKg = flight.carbonKg > 0 ? flight.carbonKg : null;
     } else {
       _selectedAircraft = aircrafts.first;
       _aircraftController.text = _selectedAircraft!.display;
@@ -191,6 +200,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       seatNumber: _seatNumberController.text,
       seatLocation: _seatLocation,
       distanceKm: _distanceKm ?? widget.flight?.distanceKm ?? 0,
+      carbonKg: _carbonKg ?? widget.flight?.carbonKg ?? 0,
       isFavorite: widget.flight?.isFavorite ?? false,
     );
     Navigator.of(context).pop(flight);

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -45,6 +45,9 @@ class FlightDetailScreen extends StatelessWidget {
     if (flight.distanceKm > 0) {
       items.add(_tile('Distance', '${flight.distanceKm.round()} km'));
     }
+    if (flight.carbonKg > 0) {
+      items.add(_tile('Carbon', '${flight.carbonKg.round()} kg CO₂'));
+    }
     if (flight.travelClass.isNotEmpty) {
       items.add(_tile('Class', flight.travelClass));
     }

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -92,6 +92,7 @@ class _FlightScreenState extends State<FlightScreen> {
       seatNumber: flight.seatNumber,
       seatLocation: flight.seatLocation,
       distanceKm: flight.distanceKm,
+      carbonKg: flight.carbonKg,
       isFavorite: !flight.isFavorite,
     );
     widget.flightsNotifier.value = list;

--- a/lib/utils/carbon_utils.dart
+++ b/lib/utils/carbon_utils.dart
@@ -1,0 +1,33 @@
+import 'dart:math' as math;
+
+/// Default emission factors in kilograms CO₂ per kilometer for some aircraft.
+/// These are simplified values for demonstration purposes.
+const Map<String, double> aircraftFactors = {
+  'Airbus A320': 0.09,
+  'Airbus A321': 0.09,
+  'Boeing 737': 0.09,
+  'Boeing 777': 0.11,
+  'Boeing 787': 0.10,
+};
+
+/// Adjustment multipliers based on travel class.
+const Map<String, double> classFactors = {
+  'Economy': 1.0,
+  'Premium': 1.2,
+  'Business': 1.5,
+  'First': 2.0,
+};
+
+/// Estimates the carbon emissions in kilograms for a flight.
+///
+/// [distanceKm] is the flight distance in kilometers, [aircraft] is the
+/// aircraft model, and [travelClass] is the passenger class such as
+/// Economy or Business. If the aircraft or class is not found in the maps,
+/// default factors are used.
+double estimateEmissions(
+    double distanceKm, String aircraft, String travelClass) {
+  final aircraftFactor =
+      aircraftFactors[aircraft] ?? aircraftFactors.values.first;
+  final classFactor = classFactors[travelClass] ?? 1.0;
+  return distanceKm * aircraftFactor * classFactor;
+}


### PR DESCRIPTION
## Summary
- add carbon emission estimation utility
- store carbonKg on `Flight`
- compute emissions in add/edit screen
- show emissions in flight details
- maintain carbon value when toggling favorites

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*