### PR TITLE
Improve flight detail styling and map fit

### DIFF
--- a/lib/widgets/info_row.dart
+++ b/lib/widgets/info_row.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class InfoRow extends StatelessWidget {
+  final String title;
+  final String value;
+  final IconData? icon;
+
+  const InfoRow({
+    super.key,
+    required this.title,
+    required this.value,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[];
+    if (icon != null) {
+      children.add(Icon(icon, color: Theme.of(context).colorScheme.primary));
+      children.add(const SizedBox(width: 12));
+    }
+    children.add(
+      Expanded(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 2),
+            Text(value, style: Theme.of(context).textTheme.bodyMedium),
+          ],
+        ),
+      ),
+    );
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(children: children),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `InfoRow` widget for card-style info rows
- refactor `FlightDetailScreen` to use `InfoRow`
- compute map bounds to fit route and use dark tile layer

## Testing
- `dart` and `flutter` not available in container so no tests run