### PR TITLE
Add CO₂ stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - View a list of all recorded flights
 - View overall stats like total flights and hours
 - See your top airlines in the Status section
+- View total CO₂ emissions per passenger in the Status section
 - Track progress with detailed achievements for flight counts, distance and destinations
 - Switch between light and dark themes
 - Theme preference is saved so your choice is remembered

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -199,7 +199,10 @@ class FlightDetailScreen extends StatelessWidget {
       items.add(InfoRow(title: 'Distance', value: '${flight.distanceKm.round()} km', icon: Icons.straighten));
     }
     if (flight.carbonKg > 0) {
-      items.add(InfoRow(title: 'Carbon', value: '${flight.carbonKg.round()} kg CO₂', icon: Icons.cloud));
+      items.add(InfoRow(
+          title: 'CO₂ per passenger',
+          value: '${flight.carbonKg.round()} kg',
+          icon: Icons.cloud));
     }
     if (flight.travelClass.isNotEmpty) {
       items.add(InfoRow(title: 'Class', value: flight.travelClass, icon: Icons.chair));

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -54,6 +54,13 @@ class _StatusScreenState extends State<StatusScreen> {
     });
   }
 
+  double get _totalCarbon {
+    return _flights.fold(0.0, (previousValue, element) {
+      final carbon = element.carbonKg;
+      return previousValue + (carbon.isNaN ? 0 : carbon);
+    });
+  }
+
   int get _favoriteCount =>
       _flights.where((f) => f.isFavorite).length;
 
@@ -148,6 +155,11 @@ class _StatusScreenState extends State<StatusScreen> {
                   icon: Icons.schedule,
                   label: 'Total duration',
                   value: '${_totalDuration.toStringAsFixed(1)} hrs',
+                ),
+                _StatusTile(
+                  icon: Icons.cloud,
+                  label: 'Total CO₂',
+                  value: '${_totalCarbon.round()} kg',
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- show per passenger CO₂ on flight details
- track total CO₂ across flights and show in Status screen
- mention CO₂ stats in README

## Testing
- `git status --short`