### PR TITLE
Add monthly chart to status

### DIFF
--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -5,6 +5,7 @@ import '../models/flight_storage.dart';
 import '../data/airport_data.dart';
 import '../widgets/class_pie_chart.dart';
 import '../widgets/skybook_app_bar.dart';
+import '../widgets/flight_line_chart.dart';
 
 class StatusScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
@@ -121,6 +122,19 @@ class _StatusScreenState extends State<StatusScreen> {
     return counts;
   }
 
+  Map<DateTime, int> get _monthlyFlightCounts {
+    final counts = <DateTime, int>{};
+    for (final f in _flights) {
+      final date = DateTime.tryParse(f.date);
+      if (date != null) {
+        final key = DateTime(date.year, date.month);
+        counts[key] = (counts[key] ?? 0) + 1;
+      }
+    }
+    final keys = counts.keys.toList()..sort();
+    return {for (final k in keys) k: counts[k]!};
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -163,6 +177,8 @@ class _StatusScreenState extends State<StatusScreen> {
                 ),
               ],
             ),
+            const SizedBox(height: 24),
+            _buildMonthlyChart(),
             const SizedBox(height: 24),
             _buildAircraftChart(),
             const SizedBox(height: 24),
@@ -255,6 +271,22 @@ class _StatusScreenState extends State<StatusScreen> {
             style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 8),
         ClassPieChart(counts: _classCount),
+      ],
+    );
+  }
+
+  Widget _buildMonthlyChart() {
+    if (_flights.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Flights per Month',
+            style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        FlightLineChart(counts: _monthlyFlightCounts),
       ],
     );
   }

--- a/lib/widgets/flight_line_chart.dart
+++ b/lib/widgets/flight_line_chart.dart
@@ -1,0 +1,95 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class FlightLineChart extends StatelessWidget {
+  final Map<DateTime, int> counts;
+  final double height;
+
+  const FlightLineChart({super.key, required this.counts, this.height = 150});
+
+  @override
+  Widget build(BuildContext context) {
+    if (counts.isEmpty) return const SizedBox.shrink();
+    final sortedKeys = counts.keys.toList()..sort();
+    final data = [for (final k in sortedKeys) counts[k] ?? 0];
+    final labels = [for (final k in sortedKeys) DateFormat.yMMM().format(k)];
+    final lineColor = Theme.of(context).colorScheme.primary;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: height,
+          width: double.infinity,
+          child: CustomPaint(
+            painter: _LineChartPainter(data, lineColor),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: labels
+              .map((l) => Expanded(
+                    child: Text(
+                      l,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ))
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _LineChartPainter extends CustomPainter {
+  final List<int> counts;
+  final Color color;
+
+  _LineChartPainter(this.counts, this.color);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (counts.isEmpty) return;
+    final maxCount = counts.reduce(math.max);
+    final stepX = counts.length <= 1 ? size.width : size.width / (counts.length - 1);
+    final points = <Offset>[];
+    for (var i = 0; i < counts.length; i++) {
+      final x = stepX * i;
+      final y = size.height - (counts[i] / math.max(1, maxCount) * size.height);
+      points.add(Offset(x, y));
+    }
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    final path = Path();
+    for (var i = 0; i < points.length; i++) {
+      if (i == 0) {
+        path.moveTo(points[i].dx, points[i].dy);
+      } else {
+        path.lineTo(points[i].dx, points[i].dy);
+      }
+    }
+    canvas.drawPath(path, paint);
+
+    final dotPaint = Paint()..color = color;
+    for (final p in points) {
+      canvas.drawCircle(p, 3, dotPaint);
+    }
+
+    // Draw baseline
+    final basePaint = Paint()
+      ..color = color.withOpacity(0.3)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(0, size.height), Offset(size.width, size.height), basePaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _LineChartPainter oldDelegate) {
+    return oldDelegate.counts != counts || oldDelegate.color != color;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `FlightLineChart` custom painter widget
- compute monthly flight totals
- display new line chart on status page before the other charts

## Testing
- `flutter --version` *(fails: command not found)*