### PR TITLE
Fix progress bar string interpolation

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -154,12 +154,12 @@ class _ProgressScreenState extends State<ProgressScreen>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('$unlocked of \${filtered.length} Achievements unlocked',
+            Text('$unlocked of ${filtered.length} Achievements unlocked',
                 style: Theme.of(context).textTheme.bodyMedium),
             const SizedBox(height: 8),
             Semantics(
               label:
-                  '$unlocked of \${filtered.length} achievements unlocked',
+                  '$unlocked of ${filtered.length} achievements unlocked',
               child: LinearProgressIndicator(
                 value: ratio,
                 minHeight: 6,


### PR DESCRIPTION
## Summary
- fix interpolation for achievement count in progress screen

## Testing
- `flutter --version` *(fails: command not found)*