### PR TITLE
Improve flight detail zoom logic

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
-import 'dart:math' as math;
 
 import '../utils/map_utils.dart';
 import '../models/flight.dart';
@@ -33,38 +32,9 @@ class FlightDetailScreen extends StatelessWidget {
     final start = LatLng(origin.latitude, origin.longitude);
     final end = LatLng(dest.latitude, dest.longitude);
     final routePoints = MapUtils.arcPoints(start, end);
-
-    double minLat = routePoints.first.latitude;
-    double maxLat = routePoints.first.latitude;
-    double minLon = routePoints.first.longitude;
-    double maxLon = routePoints.first.longitude;
-    for (final p in routePoints) {
-      if (p.latitude < minLat) minLat = p.latitude;
-      if (p.latitude > maxLat) maxLat = p.latitude;
-      if (p.longitude < minLon) minLon = p.longitude;
-      if (p.longitude > maxLon) maxLon = p.longitude;
-    }
-
-    double diffLon = (maxLon - minLon).abs();
-    double centerLon;
-    if (diffLon > 180) {
-      diffLon = 360 - diffLon;
-      centerLon = (minLon + maxLon + 360) / 2;
-      if (centerLon > 180) centerLon -= 360;
-    } else {
-      centerLon = (minLon + maxLon) / 2;
-    }
-
-    final center = LatLng(
-      (minLat + maxLat) / 2,
-      centerLon,
-    );
-
-    final diffLat = (maxLat - minLat).abs();
-    final diff = math.max(diffLat, diffLon);
-    var zoom = (math.log(360 / diff) / math.ln2) + 1;
-    if (zoom.isNaN || zoom.isInfinite) zoom = 3;
-    zoom = zoom.clamp(2.0, 16.0);
+    final view = MapUtils.viewForPoints(routePoints);
+    final center = view.center;
+    final zoom = view.zoom;
 
     final markers = [
       Marker(

--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -47,4 +47,51 @@ class MapUtils {
     }
     return pts;
   }
+
+  /// Data class holding the map [center] and [zoom] level.
+  static MapView viewForPoints(List<LatLng> points,
+      {double minZoom = 2.0, double maxZoom = 16.0}) {
+    if (points.isEmpty) {
+      return MapView(center: const LatLng(0, 0), zoom: 3);
+    }
+
+    double minLat = points.first.latitude;
+    double maxLat = points.first.latitude;
+    double minLon = points.first.longitude;
+    double maxLon = points.first.longitude;
+    for (final p in points) {
+      if (p.latitude < minLat) minLat = p.latitude;
+      if (p.latitude > maxLat) maxLat = p.latitude;
+      if (p.longitude < minLon) minLon = p.longitude;
+      if (p.longitude > maxLon) maxLon = p.longitude;
+    }
+
+    double diffLon = (maxLon - minLon).abs();
+    double centerLon;
+    if (diffLon > 180) {
+      diffLon = 360 - diffLon;
+      centerLon = (minLon + maxLon + 360) / 2;
+      if (centerLon > 180) centerLon -= 360;
+    } else {
+      centerLon = (minLon + maxLon) / 2;
+    }
+
+    final center = LatLng((minLat + maxLat) / 2, centerLon);
+
+    final diffLat = (maxLat - minLat).abs();
+    final diff = math.max(diffLat, diffLon);
+    var zoom = (math.log(360 / diff) / math.ln2) + 1;
+    if (zoom.isNaN || zoom.isInfinite) zoom = 3;
+    zoom = zoom.clamp(minZoom, maxZoom);
+
+    return MapView(center: center, zoom: zoom);
+  }
+}
+
+/// Simple holder for a map's center point and zoom level.
+class MapView {
+  final LatLng center;
+  final double zoom;
+
+  const MapView({required this.center, required this.zoom});
 }


### PR DESCRIPTION
## Summary
- factor out map view calculations to `MapUtils.viewForPoints`
- use `viewForPoints` in `FlightDetailScreen` to determine map center and zoom

## Testing
- `dart format lib/utils/map_utils.dart lib/screens/flight_detail_screen.dart` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*