### PR TITLE
Add Premium mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Theme preference is saved so your choice is remembered
 - Enable a developer section with an option to clear local data
 - Developer section preference is saved so your choice is remembered
+- Unlock Premium mode in settings to view CO₂ data and detailed graphs
 - Data is stored locally on the device
 - View your routes on an interactive map
 - Quickly access Map, Flights, Progress and Status using the bottom navigation bar

--- a/lib/models/premium_storage.dart
+++ b/lib/models/premium_storage.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PremiumStorage {
+  static const String _key = 'premiumStatus';
+
+  static Future<bool> loadPremium() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? false;
+  }
+
+  static Future<void> savePremium(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, enabled);
+  }
+}

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -8,6 +8,7 @@ import '../data/airport_data.dart';
 import 'add_flight_screen.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/info_row.dart';
+import '../models/premium_storage.dart';
 
 class FlightDetailScreen extends StatelessWidget {
   final Flight flight;
@@ -136,10 +137,20 @@ class FlightDetailScreen extends StatelessWidget {
       items.add(InfoRow(title: 'Distance', value: '${flight.distanceKm.round()} km', icon: Icons.straighten));
     }
     if (flight.carbonKg > 0) {
-      items.add(InfoRow(
-          title: 'CO₂ per passenger',
-          value: '${flight.carbonKg.round()} kg',
-          icon: Icons.cloud));
+      items.add(
+        FutureBuilder<bool>(
+          future: PremiumStorage.loadPremium(),
+          builder: (context, snapshot) {
+            final premium = snapshot.data ?? false;
+            if (!premium) return const SizedBox.shrink();
+            return InfoRow(
+              title: 'CO₂ per passenger',
+              value: '${flight.carbonKg.round()} kg',
+              icon: Icons.cloud,
+            );
+          },
+        ),
+      );
     }
     if (flight.travelClass.isNotEmpty) {
       items.add(InfoRow(title: 'Class', value: flight.travelClass, icon: Icons.chair));

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../models/developer_storage.dart';
+import '../models/premium_storage.dart';
 
 class SettingsScreen extends StatefulWidget {
   final bool darkMode;
@@ -21,11 +22,13 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _developerMode = false;
+  bool _premium = false;
 
   @override
   void initState() {
     super.initState();
     _loadDeveloperMode();
+    _loadPremium();
   }
 
   Future<void> _loadDeveloperMode() async {
@@ -33,6 +36,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) {
       setState(() {
         _developerMode = saved;
+      });
+    }
+  }
+
+  Future<void> _loadPremium() async {
+    final saved = await PremiumStorage.loadPremium();
+    if (mounted) {
+      setState(() {
+        _premium = saved;
       });
     }
   }
@@ -59,6 +71,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: const Text('Dark Mode'),
             value: widget.darkMode,
             onChanged: (_) => widget.onToggleTheme(),
+          ),
+          SwitchListTile(
+            title: const Text('Premium'),
+            value: _premium,
+            onChanged: (val) {
+              setState(() {
+                _premium = val;
+              });
+              PremiumStorage.savePremium(val);
+            },
           ),
           SwitchListTile(
             title: const Text('Developer section'),

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -6,6 +6,7 @@ import '../data/airport_data.dart';
 import '../widgets/class_pie_chart.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/flight_line_chart.dart';
+import '../models/premium_storage.dart';
 
 class StatusScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
@@ -24,11 +25,13 @@ class StatusScreen extends StatefulWidget {
 class _StatusScreenState extends State<StatusScreen> {
   List<Flight> _flights = [];
   late VoidCallback _listener;
+  bool _premium = false;
 
   @override
   void initState() {
     super.initState();
     _flights = widget.flightsNotifier.value;
+    _loadPremium();
     _listener = () {
       setState(() {
         _flights = widget.flightsNotifier.value;
@@ -41,6 +44,15 @@ class _StatusScreenState extends State<StatusScreen> {
   void dispose() {
     widget.flightsNotifier.removeListener(_listener);
     super.dispose();
+  }
+
+  Future<void> _loadPremium() async {
+    final saved = await PremiumStorage.loadPremium();
+    if (mounted) {
+      setState(() {
+        _premium = saved;
+      });
+    }
   }
 
   Future<void> refresh() async {
@@ -170,23 +182,26 @@ class _StatusScreenState extends State<StatusScreen> {
                   label: 'Total duration',
                   value: '${_totalDuration.toStringAsFixed(1)} hrs',
                 ),
-                _StatusTile(
-                  icon: Icons.cloud,
-                  label: 'Total CO₂',
-                  value: '${_totalCarbon.round()} kg',
-                ),
+                if (_premium)
+                  _StatusTile(
+                    icon: Icons.cloud,
+                    label: 'Total CO₂',
+                    value: '${_totalCarbon.round()} kg',
+                  ),
               ],
             ),
-            const SizedBox(height: 24),
-            _buildMonthlyChart(),
-            const SizedBox(height: 24),
-            _buildAircraftChart(),
-            const SizedBox(height: 24),
-            _buildAirlineChart(),
-            const SizedBox(height: 24),
-            _buildCountryChart(),
-            const SizedBox(height: 24),
-            _buildClassChart(),
+            if (_premium) ...[
+              const SizedBox(height: 24),
+              _buildMonthlyChart(),
+              const SizedBox(height: 24),
+              _buildAircraftChart(),
+              const SizedBox(height: 24),
+              _buildAirlineChart(),
+              const SizedBox(height: 24),
+              _buildCountryChart(),
+              const SizedBox(height: 24),
+              _buildClassChart(),
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add `PremiumStorage` for saving premium status
- add toggle for Premium in settings
- hide CO₂ information and detailed graphs unless Premium is enabled
- document new Premium feature

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*