### PR TITLE
Fix const LatLng usage

### DIFF
--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -52,7 +52,7 @@ class MapUtils {
   static MapView viewForPoints(List<LatLng> points,
       {double minZoom = 2.0, double maxZoom = 16.0}) {
     if (points.isEmpty) {
-      return MapView(center: const LatLng(0, 0), zoom: 3);
+      return MapView(center: LatLng(0, 0), zoom: 3);
     }
 
     double minLat = points.first.latitude;


### PR DESCRIPTION
## Summary
- remove const constructor call for LatLng in `map_utils.dart`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*