### PR TITLE
Update map interaction for flight details

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -80,7 +80,9 @@ class FlightDetailScreen extends StatelessWidget {
         options: MapOptions(
           center: center,
           zoom: zoom,
-          interactiveFlags: InteractiveFlag.pinchZoom | InteractiveFlag.drag,
+          minZoom: zoom,
+          maxZoom: zoom,
+          interactiveFlags: InteractiveFlag.drag,
         ),
         children: [
           TileLayer(


### PR DESCRIPTION
## Summary
- disable map zoom on flight detail screen to keep route fully visible

## Testing
- `flutter test` *(fails: `flutter: command not found`)*