### PR TITLE
Ensure premium toggle updates immediately

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'models/achievement_storage.dart';
 import 'utils/achievement_utils.dart';
 import 'screens/home_screen.dart';
 import 'widgets/achievement_dialog.dart';
+import 'models/premium_storage.dart';
 
 const Color _brandPrimary = Color(0xFF0A73B1);
 const Color _brandSecondary = Color(0xFFEF6C00);
@@ -34,6 +35,7 @@ class SkyBookApp extends StatefulWidget {
 class _SkyBookAppState extends State<SkyBookApp> {
   bool _darkMode = false;
   final ValueNotifier<List<Flight>> _flightsNotifier = ValueNotifier<List<Flight>>([]);
+  final ValueNotifier<bool> _premiumNotifier = ValueNotifier<bool>(false);
   final GlobalKey<ScaffoldMessengerState> _messengerKey = GlobalKey<ScaffoldMessengerState>();
   final Map<String, DateTime> _unlockedAchievements = {};
 
@@ -69,6 +71,7 @@ class _SkyBookAppState extends State<SkyBookApp> {
     super.initState();
     _loadAchievements().then((_) => _loadFlights());
     _loadTheme();
+    _loadPremium();
   }
 
   Future<void> _loadFlights() async {
@@ -100,6 +103,11 @@ class _SkyBookAppState extends State<SkyBookApp> {
     }
   }
 
+  Future<void> _loadPremium() async {
+    final saved = await PremiumStorage.loadPremium();
+    _premiumNotifier.value = saved;
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -122,6 +130,7 @@ class _SkyBookAppState extends State<SkyBookApp> {
         onToggleTheme: _toggleTheme,
         darkMode: _darkMode,
         flightsNotifier: _flightsNotifier,
+        premiumNotifier: _premiumNotifier,
         onFlightsChanged: _saveFlights,
         unlockedAchievements: _unlockedAchievements,
       ),

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -8,11 +8,16 @@ import '../data/airport_data.dart';
 import 'add_flight_screen.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/info_row.dart';
-import '../models/premium_storage.dart';
 
 class FlightDetailScreen extends StatelessWidget {
   final Flight flight;
-  const FlightDetailScreen({super.key, required this.flight});
+  final ValueNotifier<bool> premiumNotifier;
+
+  const FlightDetailScreen({
+    super.key,
+    required this.flight,
+    required this.premiumNotifier,
+  });
 
   Future<void> _edit(BuildContext context) async {
     final result = await Navigator.of(context).push<dynamic>(
@@ -138,10 +143,9 @@ class FlightDetailScreen extends StatelessWidget {
     }
     if (flight.carbonKg > 0) {
       items.add(
-        FutureBuilder<bool>(
-          future: PremiumStorage.loadPremium(),
-          builder: (context, snapshot) {
-            final premium = snapshot.data ?? false;
+        ValueListenableBuilder<bool>(
+          valueListenable: premiumNotifier,
+          builder: (context, premium, _) {
             if (!premium) return const SizedBox.shrink();
             return InfoRow(
               title: 'CO₂ per passenger',

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -10,12 +10,14 @@ import '../widgets/skybook_app_bar.dart';
 class FlightScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
   final ValueNotifier<List<Flight>> flightsNotifier;
+  final ValueNotifier<bool> premiumNotifier;
   final Future<void> Function() onFlightsChanged;
 
   const FlightScreen({
     super.key,
     required this.onOpenSettings,
     required this.flightsNotifier,
+    required this.premiumNotifier,
     required this.onFlightsChanged,
   });
 
@@ -85,7 +87,10 @@ class _FlightScreenState extends State<FlightScreen> {
   Future<void> _viewFlight(int index) async {
     final result = await Navigator.of(context).push<dynamic>(
       MaterialPageRoute(
-        builder: (_) => FlightDetailScreen(flight: _flights[index]),
+        builder: (_) => FlightDetailScreen(
+          flight: _flights[index],
+          premiumNotifier: widget.premiumNotifier,
+        ),
       ),
     );
     if (result is Flight) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ class HomeScreen extends StatefulWidget {
   final VoidCallback onToggleTheme;
   final bool darkMode;
   final ValueNotifier<List<Flight>> flightsNotifier;
+  final ValueNotifier<bool> premiumNotifier;
   final Future<void> Function() onFlightsChanged;
   final Map<String, DateTime> unlockedAchievements;
 
@@ -19,6 +20,7 @@ class HomeScreen extends StatefulWidget {
     required this.onToggleTheme,
     required this.darkMode,
     required this.flightsNotifier,
+    required this.premiumNotifier,
     required this.onFlightsChanged,
     required this.unlockedAchievements,
   });
@@ -51,6 +53,7 @@ class _HomeScreenState extends State<HomeScreen> {
           darkMode: widget.darkMode,
           onToggleTheme: widget.onToggleTheme,
           onClearData: _handleDataCleared,
+          premiumNotifier: widget.premiumNotifier,
         ),
       ),
     );
@@ -74,6 +77,7 @@ class _HomeScreenState extends State<HomeScreen> {
         key: _flightScreenKey,
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
+        premiumNotifier: widget.premiumNotifier,
         onFlightsChanged: widget.onFlightsChanged,
       ),
       ProgressScreen(
@@ -86,6 +90,7 @@ class _HomeScreenState extends State<HomeScreen> {
         key: _statusScreenKey,
         onOpenSettings: _openSettings,
         flightsNotifier: widget.flightsNotifier,
+        premiumNotifier: widget.premiumNotifier,
       ),
     ];
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,12 +8,14 @@ class SettingsScreen extends StatefulWidget {
   final bool darkMode;
   final VoidCallback onToggleTheme;
   final VoidCallback? onClearData;
+  final ValueNotifier<bool> premiumNotifier;
 
   const SettingsScreen({
     super.key,
     required this.darkMode,
     required this.onToggleTheme,
     this.onClearData,
+    required this.premiumNotifier,
   });
 
   @override
@@ -22,13 +24,11 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _developerMode = false;
-  bool _premium = false;
 
   @override
   void initState() {
     super.initState();
     _loadDeveloperMode();
-    _loadPremium();
   }
 
   Future<void> _loadDeveloperMode() async {
@@ -36,15 +36,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) {
       setState(() {
         _developerMode = saved;
-      });
-    }
-  }
-
-  Future<void> _loadPremium() async {
-    final saved = await PremiumStorage.loadPremium();
-    if (mounted) {
-      setState(() {
-        _premium = saved;
       });
     }
   }
@@ -72,14 +63,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
             value: widget.darkMode,
             onChanged: (_) => widget.onToggleTheme(),
           ),
-          SwitchListTile(
-            title: const Text('Premium'),
-            value: _premium,
-            onChanged: (val) {
-              setState(() {
-                _premium = val;
-              });
-              PremiumStorage.savePremium(val);
+          ValueListenableBuilder<bool>(
+            valueListenable: widget.premiumNotifier,
+            builder: (context, value, _) {
+              return SwitchListTile(
+                title: const Text('Premium'),
+                value: value,
+                onChanged: (val) {
+                  widget.premiumNotifier.value = val;
+                  PremiumStorage.savePremium(val);
+                },
+              );
             },
           ),
           SwitchListTile(

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -6,16 +6,17 @@ import '../data/airport_data.dart';
 import '../widgets/class_pie_chart.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/flight_line_chart.dart';
-import '../models/premium_storage.dart';
 
 class StatusScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
   final ValueNotifier<List<Flight>> flightsNotifier;
+  final ValueNotifier<bool> premiumNotifier;
 
   const StatusScreen({
     super.key,
     required this.onOpenSettings,
     required this.flightsNotifier,
+    required this.premiumNotifier,
   });
 
   @override
@@ -26,12 +27,21 @@ class _StatusScreenState extends State<StatusScreen> {
   List<Flight> _flights = [];
   late VoidCallback _listener;
   bool _premium = false;
+  late VoidCallback _premiumListener;
 
   @override
   void initState() {
     super.initState();
     _flights = widget.flightsNotifier.value;
-    _loadPremium();
+    _premium = widget.premiumNotifier.value;
+    _premiumListener = () {
+      if (mounted) {
+        setState(() {
+          _premium = widget.premiumNotifier.value;
+        });
+      }
+    };
+    widget.premiumNotifier.addListener(_premiumListener);
     _listener = () {
       setState(() {
         _flights = widget.flightsNotifier.value;
@@ -43,16 +53,8 @@ class _StatusScreenState extends State<StatusScreen> {
   @override
   void dispose() {
     widget.flightsNotifier.removeListener(_listener);
+    widget.premiumNotifier.removeListener(_premiumListener);
     super.dispose();
-  }
-
-  Future<void> _loadPremium() async {
-    final saved = await PremiumStorage.loadPremium();
-    if (mounted) {
-      setState(() {
-        _premium = saved;
-      });
-    }
   }
 
   Future<void> refresh() async {


### PR DESCRIPTION
## Summary
- keep track of premium state with a ValueNotifier
- use the notifier across the app so premium changes refresh live
- show the carbon row in flight details only when premium is enabled

## Testing
- `flutter --version` *(fails: command not found)*