### PR TITLE
Add sharing for unlocked achievements

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -5,6 +5,7 @@ import '../models/flight_storage.dart';
 import '../utils/achievement_utils.dart';
 import 'package:intl/intl.dart';
 import '../widgets/skybook_app_bar.dart';
+import 'package:share_plus/share_plus.dart';
 
 class ProgressScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
@@ -187,6 +188,11 @@ class _ProgressScreenState extends State<ProgressScreen>
                     title: Text(a.title),
                     content: Text(a.description),
                     actions: [
+                      if (a.achieved)
+                        TextButton(
+                          onPressed: () => Share.share(a.description),
+                          child: const Text('Share'),
+                        ),
                       TextButton(
                         onPressed: () => Navigator.of(context).pop(),
                         child: const Text('OK'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   # google_fonts: ^5.1.0
   google_fonts: ^4.0.4
   intl: ^0.18.0
+  share_plus: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow achievements to be shared
- add `share_plus` dependency

## Testing
- `flutter test` *(fails: flutter not installed)*