### PR TITLE
Enable airport list selection

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -14,8 +14,9 @@ import '../utils/carbon_utils.dart';
 
 class AddFlightScreen extends StatefulWidget {
   final Flight? flight;
+  final List<Flight> flights;
 
-  const AddFlightScreen({super.key, this.flight});
+  const AddFlightScreen({super.key, this.flight, required this.flights});
 
   @override
   State<AddFlightScreen> createState() => _AddFlightScreenState();
@@ -45,6 +46,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
 
   Aircraft? _selectedAircraft;
   Airline? _selectedAirline;
+  late final Set<String> _flightAirportCodes;
 
   void _computeDistance() {
     final origin =
@@ -119,6 +121,12 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       _aircraftController.text = _selectedAircraft!.display;
       _selectedAirline = null;
     }
+    _flightAirportCodes = {
+      for (final f in widget.flights) ...[
+        f.origin.toUpperCase(),
+        f.destination.toUpperCase(),
+      ]
+    };
     _computeDistance();
   }
 
@@ -213,7 +221,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       focusNode: focusNode,
       optionsBuilder: (TextEditingValue value) {
         if (value.text.isEmpty) {
-          return const Iterable<Airport>.empty();
+          // When no text is entered show only airports that are already
+          // part of the registered flights so the list is manageable.
+          return airports
+              .where((a) => _flightAirportCodes.contains(a.code));
         }
         return airports.where((a) =>
             a.code.toLowerCase().contains(value.text.toLowerCase()) ||

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -13,16 +13,19 @@ import 'package:share_plus/share_plus.dart';
 class FlightDetailScreen extends StatelessWidget {
   final Flight flight;
   final ValueNotifier<bool> premiumNotifier;
+  final List<Flight> flights;
 
   const FlightDetailScreen({
     super.key,
     required this.flight,
     required this.premiumNotifier,
+    required this.flights,
   });
 
   Future<void> _edit(BuildContext context) async {
     final result = await Navigator.of(context).push<dynamic>(
-      MaterialPageRoute(builder: (_) => AddFlightScreen(flight: flight)),
+      MaterialPageRoute(
+          builder: (_) => AddFlightScreen(flight: flight, flights: flights)),
     );
     if (result != null) {
       Navigator.of(context).pop(result);

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -141,7 +141,8 @@ class _FlightScreenState extends State<FlightScreen> {
 
   Future<void> _addFlight() async {
     final newFlight = await Navigator.of(context).push<Flight>(
-      MaterialPageRoute(builder: (_) => const AddFlightScreen()),
+      MaterialPageRoute(
+          builder: (_) => AddFlightScreen(flights: _allFlights)),
     );
     if (newFlight != null) {
       _allFlights = List<Flight>.from(_allFlights)..add(newFlight);
@@ -156,7 +157,10 @@ class _FlightScreenState extends State<FlightScreen> {
   Future<void> _editFlight(int index) async {
     final result = await Navigator.of(context).push<dynamic>(
       MaterialPageRoute(
-        builder: (_) => AddFlightScreen(flight: _flights[index]),
+        builder: (_) => AddFlightScreen(
+          flight: _flights[index],
+          flights: _allFlights,
+        ),
       ),
     );
     if (result is Flight) {
@@ -197,6 +201,7 @@ class _FlightScreenState extends State<FlightScreen> {
         builder: (_) => FlightDetailScreen(
           flight: _flights[index],
           premiumNotifier: widget.premiumNotifier,
+          flights: _allFlights,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- update airport autocomplete so that a list of used airports is shown when the input is empty
- wire screens to pass flight list into AddFlightScreen

## Testing
- `flutter --version` *(fails: command not found)*