### PR TITLE
Use provided achievement icon

### DIFF
--- a/lib/models/achievement.dart
+++ b/lib/models/achievement.dart
@@ -5,7 +5,8 @@ class Achievement {
   final String title;
   final String description;
   final String category;
-  final IconData icon;
+  final IconData? icon;
+  final String? iconAsset;
   final int target;
   final int progress;
   final bool achieved;
@@ -16,11 +17,25 @@ class Achievement {
     required this.title,
     required this.description,
     required this.category,
-    required this.icon,
+    this.icon,
+    this.iconAsset,
     required this.target,
     required this.progress,
     required this.achieved,
     this.unlockedAt,
-  });
+  }) : assert(icon != null || iconAsset != null,
+            'Either icon or iconAsset must be provided');
+
+  Widget buildIcon({Color? color, double? size}) {
+    if (iconAsset != null) {
+      return Image.asset(
+        iconAsset!,
+        width: size,
+        height: size,
+        color: color,
+      );
+    }
+    return Icon(icon, color: color, size: size);
+  }
 }
 

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -205,8 +205,7 @@ class _ProgressScreenState extends State<ProgressScreen>
                 children: [
                   Padding(
                     padding: const EdgeInsets.only(right: 8),
-                    child: Icon(
-                      a.icon,
+                    child: a.buildIcon(
                       color: a.achieved ? Colors.amber : Colors.grey,
                     ),
                   ),

--- a/lib/widgets/achievement_dialog.dart
+++ b/lib/widgets/achievement_dialog.dart
@@ -28,11 +28,8 @@ class _AchievementDialogState extends State<AchievementDialog>
         children: [
           ScaleTransition(
             scale: _animation,
-            child: Icon(
-              Icons.emoji_events,
-              color: Theme.of(context).colorScheme.secondary,
-              size: 48,
-            ),
+            child: widget.achievement
+                .buildIcon(color: Theme.of(context).colorScheme.secondary, size: 48),
           ),
           const SizedBox(width: 16),
           Expanded(

--- a/test/achievement_dialog_test.dart
+++ b/test/achievement_dialog_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:skybook/widgets/achievement_dialog.dart';
+import 'package:skybook/models/achievement.dart';
+
+void main() {
+  testWidgets('achievement dialog displays provided icon', (tester) async {
+    const achievement = Achievement(
+      id: 'test',
+      title: 'Test',
+      description: '',
+      category: 'Test',
+      icon: Icons.star,
+      target: 1,
+      progress: 1,
+      achieved: true,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AchievementDialog(achievement: achievement),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.star), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- use the Achievement's icon when showing the achievement dialog
- allow achievements to reference icon data or asset icons
- update progress screen to draw icons via `buildIcon`
- add widget test to verify icon is used

## Testing
- `flutter test` *(fails: command not found)*