### PR TITLE
Add business trip toggle

### DIFF
--- a/lib/models/flight.dart
+++ b/lib/models/flight.dart
@@ -15,6 +15,7 @@ class Flight {
   final double distanceKm;
   final double carbonKg;
   final bool isFavorite;
+  final bool isBusiness;
 
   Flight({
     required this.id,
@@ -33,6 +34,7 @@ class Flight {
     this.distanceKm = 0,
     this.carbonKg = 0,
     this.isFavorite = false,
+    this.isBusiness = false,
   });
 
   Map<String, dynamic> toMap() {
@@ -53,6 +55,7 @@ class Flight {
       'distanceKm': distanceKm,
       'carbonKg': carbonKg,
       'isFavorite': isFavorite,
+      'isBusiness': isBusiness,
     };
   }
 
@@ -73,6 +76,7 @@ class Flight {
     double? distanceKm,
     double? carbonKg,
     bool? isFavorite,
+    bool? isBusiness,
   }) {
     return Flight(
       id: id ?? this.id,
@@ -91,6 +95,7 @@ class Flight {
       distanceKm: distanceKm ?? this.distanceKm,
       carbonKg: carbonKg ?? this.carbonKg,
       isFavorite: isFavorite ?? this.isFavorite,
+      isBusiness: isBusiness ?? this.isBusiness,
     );
   }
 
@@ -112,6 +117,7 @@ class Flight {
       distanceKm: (map['distanceKm'] as num?)?.toDouble() ?? 0,
       carbonKg: (map['carbonKg'] as num?)?.toDouble() ?? 0,
       isFavorite: map['isFavorite'] as bool? ?? false,
+      isBusiness: map['isBusiness'] as bool? ?? false,
     );
   }
 

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -37,6 +37,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   final _aircraftFocusNode = FocusNode();
   String _travelClass = 'Economy';
   String _seatLocation = 'Window';
+  bool _isBusiness = false;
 
   double? _distanceKm;
   double? _carbonKg;
@@ -116,6 +117,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       _seatNumberController.text = flight.seatNumber;
       _seatLocation = flight.seatLocation.isNotEmpty ? flight.seatLocation : 'Window';
       _carbonKg = flight.carbonKg > 0 ? flight.carbonKg : null;
+      _isBusiness = flight.isBusiness;
     } else {
       _selectedAircraft = aircrafts.first;
       _aircraftController.text = _selectedAircraft!.display;
@@ -180,6 +182,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
       distanceKm: _distanceKm ?? widget.flight?.distanceKm ?? 0,
       carbonKg: _carbonKg ?? widget.flight?.carbonKg ?? 0,
       isFavorite: widget.flight?.isFavorite ?? false,
+      isBusiness: _isBusiness,
     );
     Navigator.of(context).pop(flight);
   }
@@ -516,6 +519,16 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                   });
                 }
               },
+            ),
+            SwitchListTile(
+              title: const Text('Business Trip'),
+              value: _isBusiness,
+              onChanged: (v) {
+                setState(() {
+                  _isBusiness = v;
+                });
+              },
+              subtitle: Text(_isBusiness ? 'Marked as business' : 'Personal trip'),
             ),
           ],
         ),

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -177,6 +177,13 @@ class FlightDetailScreen extends StatelessWidget {
       final seat = [flight.seatNumber, flight.seatLocation].where((e) => e.isNotEmpty).join(' ');
       items.add(InfoRow(title: 'Seat', value: seat, icon: Icons.event_seat));
     }
+    items.add(
+      InfoRow(
+        title: 'Trip Type',
+        value: flight.isBusiness ? 'Business' : 'Personal',
+        icon: Icons.work,
+      ),
+    );
     if (flight.notes.isNotEmpty) {
       items.add(
         Padding(


### PR DESCRIPTION
## Summary
- add `isBusiness` flag to `Flight`
- allow marking flights as business or personal in the add/edit form
- display trip type in the flight details view

## Testing
- `flutter test` *(fails: `flutter: command not found`)*