### PR TITLE
Improve popup styling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -124,11 +124,23 @@ class _SkyBookAppState extends State<SkyBookApp> {
       theme: ThemeData(
         colorScheme: _lightColorScheme,
         textTheme: GoogleFonts.robotoTextTheme(),
+        dialogTheme: DialogTheme(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          backgroundColor: _lightColorScheme.surfaceVariant,
+        ),
         useMaterial3: true,
       ),
       darkTheme: ThemeData(
         colorScheme: _darkColorScheme,
         textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),
+        dialogTheme: DialogTheme(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          backgroundColor: _darkColorScheme.surfaceVariant,
+        ),
         useMaterial3: true,
         brightness: Brightness.dark,
       ),

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -11,6 +11,7 @@ import '../data/airline_data.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../utils/text_formatters.dart';
 import '../utils/carbon_utils.dart';
+import '../widgets/app_dialog.dart';
 
 class AddFlightScreen extends StatefulWidget {
   final Flight? flight;
@@ -190,7 +191,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   Future<void> _delete() async {
     final confirm = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
+      builder: (context) => AppDialog(
         title: const Text('Delete Flight'),
         content: const Text('Are you sure you want to delete this flight?'),
         actions: [

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -6,6 +6,7 @@ import '../utils/achievement_utils.dart';
 import 'package:intl/intl.dart';
 import '../widgets/skybook_app_bar.dart';
 import 'package:share_plus/share_plus.dart';
+import '../widgets/app_dialog.dart';
 
 class ProgressScreen extends StatefulWidget {
   final VoidCallback onOpenSettings;
@@ -184,7 +185,7 @@ class _ProgressScreenState extends State<ProgressScreen>
             onTap: () {
               showDialog(
                 context: context,
-                  builder: (context) => AlertDialog(
+                  builder: (context) => AppDialog(
                     title: Text(a.title),
                     content: Text(a.description),
                     actions: [

--- a/lib/widgets/achievement_dialog.dart
+++ b/lib/widgets/achievement_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../models/achievement.dart';
+import 'app_dialog.dart';
 
 class AchievementDialog extends StatefulWidget {
   final Achievement achievement;
@@ -22,7 +23,7 @@ class _AchievementDialogState extends State<AchievementDialog>
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
+    return AppDialog(
       title: const Text('Achievement Unlocked!'),
       content: Row(
         children: [

--- a/lib/widgets/app_dialog.dart
+++ b/lib/widgets/app_dialog.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class AppDialog extends StatelessWidget {
+  final Widget? title;
+  final Widget? content;
+  final List<Widget>? actions;
+
+  const AppDialog({super.key, this.title, this.content, this.actions});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: title,
+      content: content,
+      actions: actions,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      backgroundColor: theme.colorScheme.surfaceVariant,
+      titleTextStyle: theme.textTheme.titleLarge?.copyWith(
+        color: theme.colorScheme.primary,
+        fontWeight: FontWeight.bold,
+      ),
+      contentTextStyle: theme.textTheme.bodyMedium,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `AppDialog` widget with rounded corners and custom colors
- use `AppDialog` for achievement, progress and delete dialogs
- give `ThemeData` a `dialogTheme` for consistent styling

## Testing
- `flutter test` *(fails: `flutter: command not found`)*