### PR TITLE
Configure iOS app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - View your routes on an interactive map
 - Quickly access Map, Flights, Progress and Status using the bottom navigation bar
 - Custom badge images are included under `assets/badges` for achievements
+- The iOS app icon is generated from `assets/logo.png`
 
 ## Getting Started
 
@@ -32,5 +33,10 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
    ```sh
    flutter run
    ```
+
+To update the iOS app icon after modifying `assets/logo.png`, run:
+```sh
+flutter pub run flutter_launcher_icons:main
+```
 
 Since this repository does not include compiled dependencies, you will need to install them via `flutter pub get` before running the app.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_launcher_icons: ^0.13.1
 
 flutter:
   uses-material-design: true
@@ -28,3 +29,8 @@ flutter:
     - assets/icons/
     - assets/badges/
     - assets/logo_r.png
+
+flutter_icons:
+  image_path: assets/logo.png
+  android: false
+  ios: true


### PR DESCRIPTION
## Summary
- add `flutter_launcher_icons` dev dependency
- configure iOS app icon using `assets/logo.png`
- document how to regenerate the icon

## Testing
- `flutter --version` *(fails: command not found)*