### PR TITLE
Show logo on Progress screen

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -102,8 +102,8 @@ class _ProgressScreenState extends State<ProgressScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Progress'),
+      appBar: SkyBookAppBar(
+        title: 'Progress',
         bottom: TabBar(
           controller: _tabController,
           isScrollable: true,

--- a/lib/widgets/skybook_app_bar.dart
+++ b/lib/widgets/skybook_app_bar.dart
@@ -3,11 +3,19 @@ import 'package:flutter/material.dart';
 class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final List<Widget>? actions;
+  final PreferredSizeWidget? bottom;
 
-  const SkyBookAppBar({Key? key, required this.title, this.actions}) : super(key: key);
+  const SkyBookAppBar({
+    Key? key,
+    required this.title,
+    this.actions,
+    this.bottom,
+  }) : super(key: key);
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => Size.fromHeight(
+        kToolbarHeight + (bottom?.preferredSize.height ?? 0.0),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +28,7 @@ class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
         ],
       ),
       actions: actions,
+      bottom: bottom,
     );
   }
 }


### PR DESCRIPTION
## Summary
- support a TabBar in `SkyBookAppBar`
- use `SkyBookAppBar` on the Progress screen so the logo is displayed

## Testing
- `flutter test` *(fails: `flutter: command not found`)*