### PR TITLE
Add flight import/export

### DIFF
--- a/lib/screens/data_management_screen.dart
+++ b/lib/screens/data_management_screen.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/flight.dart';
+import '../models/flight_storage.dart';
+import '../utils/flight_serialization.dart';
+import '../widgets/skybook_app_bar.dart';
+
+class DataManagementScreen extends StatefulWidget {
+  final ValueNotifier<List<Flight>> flightsNotifier;
+  final Future<void> Function() onFlightsChanged;
+
+  const DataManagementScreen({
+    super.key,
+    required this.flightsNotifier,
+    required this.onFlightsChanged,
+  });
+
+  @override
+  State<DataManagementScreen> createState() => _DataManagementScreenState();
+}
+
+class _DataManagementScreenState extends State<DataManagementScreen> {
+  final TextEditingController _controller = TextEditingController();
+
+  void _exportJson() {
+    final data = FlightSerialization.toJson(widget.flightsNotifier.value);
+    Share.share(data, subject: 'SkyBook Flights JSON');
+  }
+
+  void _exportCsv() {
+    final data = FlightSerialization.toCsv(widget.flightsNotifier.value);
+    Share.share(data, subject: 'SkyBook Flights CSV');
+  }
+
+  Future<void> _importJson() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    try {
+      final flights = FlightSerialization.fromJson(text);
+      widget.flightsNotifier.value = flights;
+      await FlightStorage.saveFlights(flights);
+      await widget.onFlightsChanged();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Flights imported from JSON')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Invalid JSON data')),
+        );
+      }
+    }
+  }
+
+  Future<void> _importCsv() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    try {
+      final flights = FlightSerialization.fromCsv(text);
+      widget.flightsNotifier.value = flights;
+      await FlightStorage.saveFlights(flights);
+      await widget.onFlightsChanged();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Flights imported from CSV')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Invalid CSV data')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const SkyBookAppBar(title: 'Import / Export'),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ElevatedButton(
+            onPressed: _exportJson,
+            child: const Text('Export as JSON'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: _exportCsv,
+            child: const Text('Export as CSV'),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            minLines: 5,
+            maxLines: null,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: 'Import data',
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: _importJson,
+                  child: const Text('Import JSON'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: _importCsv,
+                  child: const Text('Import CSV'),
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -54,6 +54,8 @@ class _HomeScreenState extends State<HomeScreen> {
           onToggleTheme: widget.onToggleTheme,
           onClearData: _handleDataCleared,
           premiumNotifier: widget.premiumNotifier,
+          flightsNotifier: widget.flightsNotifier,
+          onFlightsChanged: widget.onFlightsChanged,
         ),
       ),
     );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,12 +3,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../models/developer_storage.dart';
 import '../models/premium_storage.dart';
+import '../models/flight.dart';
+import 'data_management_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   final bool darkMode;
   final VoidCallback onToggleTheme;
   final VoidCallback? onClearData;
   final ValueNotifier<bool> premiumNotifier;
+  final ValueNotifier<List<Flight>> flightsNotifier;
+  final Future<void> Function() onFlightsChanged;
 
   const SettingsScreen({
     super.key,
@@ -16,6 +20,8 @@ class SettingsScreen extends StatefulWidget {
     required this.onToggleTheme,
     this.onClearData,
     required this.premiumNotifier,
+    required this.flightsNotifier,
+    required this.onFlightsChanged,
   });
 
   @override
@@ -52,6 +58,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
+  void _openDataManagement() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DataManagementScreen(
+          flightsNotifier: widget.flightsNotifier,
+          onFlightsChanged: widget.onFlightsChanged,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -73,6 +90,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   widget.premiumNotifier.value = val;
                   PremiumStorage.savePremium(val);
                 },
+              );
+            },
+          ),
+          ValueListenableBuilder<bool>(
+            valueListenable: widget.premiumNotifier,
+            builder: (context, premium, _) {
+              if (!premium) return const SizedBox.shrink();
+              return ListTile(
+                title: const Text('Import / Export'),
+                trailing: const Icon(Icons.file_upload),
+                onTap: _openDataManagement,
               );
             },
           ),

--- a/lib/utils/flight_serialization.dart
+++ b/lib/utils/flight_serialization.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import '../models/flight.dart';
+
+/// Helper methods to convert flights to and from CSV or JSON.
+class FlightSerialization {
+  static const List<String> _headers = [
+    'id',
+    'date',
+    'aircraft',
+    'manufacturer',
+    'airline',
+    'callsign',
+    'duration',
+    'notes',
+    'origin',
+    'destination',
+    'travelClass',
+    'seatNumber',
+    'seatLocation',
+    'distanceKm',
+    'carbonKg',
+    'isFavorite',
+    'isBusiness'
+  ];
+
+  /// Returns a JSON string representing [flights].
+  static String toJson(List<Flight> flights) {
+    final list = flights.map((f) => f.toMap()).toList();
+    return jsonEncode(list);
+  }
+
+  /// Parses flights from JSON [data].
+  static List<Flight> fromJson(String data) {
+    final decoded = jsonDecode(data);
+    if (decoded is! List) return [];
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map((e) => Flight.fromMap(e))
+        .toList();
+  }
+
+  /// Returns a CSV string representing [flights].
+  static String toCsv(List<Flight> flights) {
+    final buffer = StringBuffer();
+    buffer.writeln(_headers.join(','));
+    for (final f in flights) {
+      final row = [
+        f.id,
+        f.date,
+        f.aircraft,
+        f.manufacturer,
+        f.airline,
+        f.callsign,
+        f.duration,
+        f.notes.replaceAll('\n', ' '),
+        f.origin,
+        f.destination,
+        f.travelClass,
+        f.seatNumber,
+        f.seatLocation,
+        f.distanceKm.toString(),
+        f.carbonKg.toString(),
+        f.isFavorite.toString(),
+        f.isBusiness.toString()
+      ];
+      buffer.writeln(row.join(','));
+    }
+    return buffer.toString();
+  }
+
+  /// Parses flights from CSV [data].
+  static List<Flight> fromCsv(String data) {
+    final lines = data.trim().split(RegExp(r'\r?\n'));
+    if (lines.isEmpty) return [];
+    final flights = <Flight>[];
+    for (var i = 1; i < lines.length; i++) {
+      final parts = lines[i].split(',');
+      if (parts.length < _headers.length) continue;
+      final map = <String, dynamic>{};
+      for (var j = 0; j < _headers.length; j++) {
+        map[_headers[j]] = _parse(parts[j]);
+      }
+      flights.add(Flight.fromMap(map));
+    }
+    return flights;
+  }
+
+  static dynamic _parse(String value) {
+    if (value == 'true') return true;
+    if (value == 'false') return false;
+    final num? number = num.tryParse(value);
+    if (number != null) return number;
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary
- enable premium users to import/export flights
- add data management screen
- allow access from settings for premium users
- support CSV and JSON flight serialization

## Testing
- `flutter test` *(fails: `flutter: command not found`)*