### PR TITLE
Fix app bar overflow

### DIFF
--- a/lib/widgets/skybook_app_bar.dart
+++ b/lib/widgets/skybook_app_bar.dart
@@ -24,7 +24,12 @@ class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
         children: [
           Image.asset('assets/logo_r.png', height: kToolbarHeight - 16),
           const SizedBox(width: 8),
-          Text(title),
+          Expanded(
+            child: Text(
+              title,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
         ],
       ),
       actions: actions,


### PR DESCRIPTION
## Summary
- make the app bar title text flexible with `Expanded`

## Testing
- `flutter test` *(fails: flutter not found)*