### PR TITLE
Switch to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SkyBook
 
-SkyBook is a simple flight logbook mobile app built with Flutter. It lets you record flights and keep notes about each one. This is an MVP designed to work offline using `shared_preferences` for persistence.
+SkyBook is a simple flight logbook mobile app built with Flutter. It lets you record flights and keep notes about each one. Data is stored offline in a local SQLite database using the `sqflite` package.
 
 ## Features
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import '../widgets/skybook_app_bar.dart';
 import '../models/developer_storage.dart';
 import '../models/premium_storage.dart';
 import '../models/flight.dart';
+import '../models/flight_storage.dart';
 import 'data_management_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -48,8 +49,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _clearData() async {
     widget.onClearData?.call();
+    await FlightStorage.saveFlights([]);
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('flights');
     await prefs.remove('achievements');
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^2.2.0
+  sqflite: ^2.3.0
+  path: ^1.8.3
   # flutter_map: ^6.1.0
   flutter_map: ^4.0.0
   latlong2: ^0.8.1


### PR DESCRIPTION
## Summary
- store flights in sqflite database instead of shared_preferences
- update settings screen to clear the database
- add sqflite to dependencies and update README

## Testing
- `flutter test` *(fails: `flutter: command not found`)*