### PR TITLE
Move reference data to SQLite

### DIFF
--- a/lib/data/aircraft_data.dart
+++ b/lib/data/aircraft_data.dart
@@ -1,7 +1,8 @@
 import '../models/aircraft.dart';
+import '../models/aircraft_storage.dart';
 
-/// List of common aircraft grouped by manufacturer.
-const List<Aircraft> aircrafts = [
+/// Seed list of common aircraft grouped by manufacturer.
+const List<Aircraft> seedAircrafts = [
   // Airbus
   Aircraft(
     manufacturer: 'Airbus',
@@ -147,6 +148,14 @@ const List<Aircraft> aircrafts = [
   ),
 ];
 
-final Map<String, Aircraft> aircraftByDisplay = {
-  for (final a in aircrafts) a.display: a,
-};
+List<Aircraft> aircrafts = [];
+Map<String, Aircraft> aircraftByDisplay = {};
+
+Future<void> loadAircraftData() async {
+  aircrafts = await AircraftStorage.loadAircrafts();
+  if (aircrafts.isEmpty) {
+    aircrafts = seedAircrafts;
+  }
+  aircraftByDisplay = {for (final a in aircrafts) a.display: a};
+}
+

--- a/lib/data/airline_data.dart
+++ b/lib/data/airline_data.dart
@@ -1,6 +1,7 @@
 import '../models/airline.dart';
+import '../models/airline_storage.dart';
 
-const List<Airline> airlines = [
+const List<Airline> seedAirlines = [
   Airline(name: 'Air France', callsign: 'AFR', code: 'AF'),
   Airline(name: 'British Airways', callsign: 'BAW', code: 'BA'),
   Airline(name: 'Emirates', callsign: 'UAE', code: 'EK'),
@@ -55,10 +56,16 @@ const List<Airline> airlines = [
   Airline(name: 'Philippine Airlines', callsign: 'PAL', code: 'PR'),
 ];
 
-final Map<String, Airline> airlineByName = {
-  for (final a in airlines) a.name: a,
-};
+List<Airline> airlines = [];
+Map<String, Airline> airlineByName = {};
+Map<String, Airline> airlineByCode = {};
 
-final Map<String, Airline> airlineByCode = {
-  for (final a in airlines) a.code: a,
-};
+Future<void> loadAirlineData() async {
+  airlines = await AirlineStorage.loadAirlines();
+  if (airlines.isEmpty) {
+    airlines = seedAirlines;
+  }
+  airlineByName = {for (final a in airlines) a.name: a};
+  airlineByCode = {for (final a in airlines) a.code: a};
+}
+

--- a/lib/data/airport_data.dart
+++ b/lib/data/airport_data.dart
@@ -1,7 +1,8 @@
 import '../models/airport.dart';
+import '../models/airport_storage.dart';
 
-/// List of major airports grouped by geographic region.
-const List<Airport> airports = [
+/// Seed list of major airports grouped by geographic region.
+const List<Airport> seedAirports = [
   // North America
   Airport(code: 'JFK', name: 'New York John F. Kennedy', country: 'United States', region: 'North America', latitude: 40.6413, longitude: -73.7781),
   Airport(code: 'LAX', name: 'Los Angeles', country: 'United States', region: 'North America', latitude: 33.9416, longitude: -118.4085),
@@ -127,9 +128,16 @@ const List<Airport> airports = [
   Airport(code: 'POS', name: 'Port of Spain Piarco', country: 'Trinidad and Tobago', region: 'South America', latitude: 10.5954, longitude: -61.3372),
 ];
 
-final Map<String, Airport> airportByCode = {
-  for (final a in airports) a.code: a,
-};
+List<Airport> airports = [];
+Map<String, Airport> airportByCode = {};
+
+Future<void> loadAirportData() async {
+  airports = await AirportStorage.loadAirports();
+  if (airports.isEmpty) {
+    airports = seedAirports;
+  }
+  airportByCode = {for (final a in airports) a.code: a};
+}
 
 /// Returns airports organized by their region.
 Map<String, List<Airport>> get airportsByRegion {
@@ -139,3 +147,4 @@ Map<String, List<Airport>> get airportsByRegion {
   }
   return map;
 }
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,9 @@ import 'screens/home_screen.dart';
 import 'screens/add_flight_screen.dart';
 import 'widgets/achievement_dialog.dart';
 import 'models/premium_storage.dart';
+import 'data/airport_data.dart';
+import 'data/airline_data.dart';
+import 'data/aircraft_data.dart';
 
 const Color _brandPrimary = Color(0xFF0A73B1);
 const Color _brandSecondary = Color(0xFFEF6C00);
@@ -108,9 +111,18 @@ class _SkyBookAppState extends State<SkyBookApp> {
     _premiumNotifier.addListener(() {
       _setupQuickActions(_premiumNotifier.value);
     });
-    _loadAchievements().then((_) => _loadFlights());
+    _loadReferenceData()
+        .then((_) => _loadAchievements().then((_) => _loadFlights()));
     _loadTheme();
     _loadPremium();
+  }
+
+  Future<void> _loadReferenceData() async {
+    await Future.wait([
+      loadAirportData(),
+      loadAirlineData(),
+      loadAircraftData(),
+    ]);
   }
 
   Future<void> _loadFlights() async {

--- a/lib/models/aircraft.dart
+++ b/lib/models/aircraft.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Aircraft {
   final String manufacturer;
   final String model;
@@ -12,4 +14,23 @@ class Aircraft {
   });
 
   String get display => '$manufacturer $model';
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': display,
+      'manufacturer': manufacturer,
+      'model': model,
+      'fuelBurnPerKm': fuelBurnPerKm,
+      'classConfig': json.encode(classConfig),
+    };
+  }
+
+  factory Aircraft.fromMap(Map<String, dynamic> map) {
+    return Aircraft(
+      manufacturer: map['manufacturer'] as String,
+      model: map['model'] as String,
+      fuelBurnPerKm: (map['fuelBurnPerKm'] as num).toDouble(),
+      classConfig: Map<String, int>.from(json.decode(map['classConfig'] as String)),
+    );
+  }
 }

--- a/lib/models/aircraft_storage.dart
+++ b/lib/models/aircraft_storage.dart
@@ -1,0 +1,12 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'aircraft.dart';
+import 'app_database.dart';
+
+class AircraftStorage {
+  static Future<List<Aircraft>> loadAircrafts() async {
+    final db = await AppDatabase.open();
+    final maps = await db.query('aircrafts');
+    return maps.map((e) => Aircraft.fromMap(e)).toList();
+  }
+}

--- a/lib/models/airline.dart
+++ b/lib/models/airline.dart
@@ -6,4 +6,20 @@ class Airline {
   const Airline({required this.name, required this.callsign, required this.code});
 
   String get display => name;
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'callsign': callsign,
+      'code': code,
+    };
+  }
+
+  factory Airline.fromMap(Map<String, dynamic> map) {
+    return Airline(
+      name: map['name'] as String,
+      callsign: map['callsign'] as String,
+      code: map['code'] as String,
+    );
+  }
 }

--- a/lib/models/airline_storage.dart
+++ b/lib/models/airline_storage.dart
@@ -1,0 +1,12 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'airline.dart';
+import 'app_database.dart';
+
+class AirlineStorage {
+  static Future<List<Airline>> loadAirlines() async {
+    final db = await AppDatabase.open();
+    final maps = await db.query('airlines');
+    return maps.map((e) => Airline.fromMap(e)).toList();
+  }
+}

--- a/lib/models/airport.dart
+++ b/lib/models/airport.dart
@@ -16,4 +16,26 @@ class Airport {
   });
 
   String get display => '$code - $name';
+
+  Map<String, dynamic> toMap() {
+    return {
+      'code': code,
+      'name': name,
+      'country': country,
+      'region': region,
+      'latitude': latitude,
+      'longitude': longitude,
+    };
+  }
+
+  factory Airport.fromMap(Map<String, dynamic> map) {
+    return Airport(
+      code: map['code'] as String,
+      name: map['name'] as String,
+      country: map['country'] as String,
+      region: map['region'] as String,
+      latitude: (map['latitude'] as num).toDouble(),
+      longitude: (map['longitude'] as num).toDouble(),
+    );
+  }
 }

--- a/lib/models/airport_storage.dart
+++ b/lib/models/airport_storage.dart
@@ -1,0 +1,12 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'airport.dart';
+import 'app_database.dart';
+
+class AirportStorage {
+  static Future<List<Airport>> loadAirports() async {
+    final db = await AppDatabase.open();
+    final maps = await db.query('airports');
+    return maps.map((e) => Airport.fromMap(e)).toList();
+  }
+}

--- a/lib/models/app_database.dart
+++ b/lib/models/app_database.dart
@@ -1,0 +1,88 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+import '../data/airport_data.dart';
+import '../data/airline_data.dart';
+import '../data/aircraft_data.dart';
+
+class AppDatabase {
+  static Database? _db;
+
+  static Future<Database> open() async {
+    if (_db != null) return _db!;
+    final path = join(await getDatabasesPath(), 'skybook.db');
+    _db = await openDatabase(
+      path,
+      version: 2,
+      onCreate: (db, version) async {
+        await _createTables(db);
+        await _seed(db);
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion < 2) {
+          await _createTables(db);
+          await _seed(db);
+        }
+      },
+    );
+    return _db!;
+  }
+
+  static Future<void> _createTables(Database db) async {
+    await db.execute('''
+CREATE TABLE IF NOT EXISTS flights(
+  id TEXT PRIMARY KEY,
+  date TEXT,
+  aircraft TEXT,
+  manufacturer TEXT,
+  airline TEXT,
+  callsign TEXT,
+  duration TEXT,
+  notes TEXT,
+  origin TEXT,
+  destination TEXT,
+  travelClass TEXT,
+  seatNumber TEXT,
+  seatLocation TEXT,
+  distanceKm REAL,
+  carbonKg REAL,
+  isFavorite INTEGER,
+  isBusiness INTEGER
+)''');
+    await db.execute('''
+CREATE TABLE IF NOT EXISTS airports(
+  code TEXT PRIMARY KEY,
+  name TEXT,
+  country TEXT,
+  region TEXT,
+  latitude REAL,
+  longitude REAL
+)''');
+    await db.execute('''
+CREATE TABLE IF NOT EXISTS airlines(
+  name TEXT PRIMARY KEY,
+  callsign TEXT,
+  code TEXT
+)''');
+    await db.execute('''
+CREATE TABLE IF NOT EXISTS aircrafts(
+  id TEXT PRIMARY KEY,
+  manufacturer TEXT,
+  model TEXT,
+  fuelBurnPerKm REAL,
+  classConfig TEXT
+)''');
+  }
+
+  static Future<void> _seed(Database db) async {
+    for (final a in seedAirports) {
+      await db.insert('airports', a.toMap(), conflictAlgorithm: ConflictAlgorithm.ignore);
+    }
+    for (final a in seedAirlines) {
+      await db.insert('airlines', a.toMap(), conflictAlgorithm: ConflictAlgorithm.ignore);
+    }
+    for (final a in seedAircrafts) {
+      await db.insert('aircrafts', a.toMap(), conflictAlgorithm: ConflictAlgorithm.ignore);
+    }
+  }
+}

--- a/lib/models/flight_storage.dart
+++ b/lib/models/flight_storage.dart
@@ -1,41 +1,12 @@
 import 'package:sqflite/sqflite.dart';
-import 'package:path/path.dart';
+
+import 'app_database.dart';
 
 import 'flight.dart';
 
 class FlightStorage {
-  static Database? _db;
-
   static Future<Database> _openDb() async {
-    if (_db != null) return _db!;
-    final path = join(await getDatabasesPath(), 'skybook.db');
-    _db = await openDatabase(
-      path,
-      version: 1,
-      onCreate: (db, version) async {
-        await db.execute('''
-CREATE TABLE flights(
-  id TEXT PRIMARY KEY,
-  date TEXT,
-  aircraft TEXT,
-  manufacturer TEXT,
-  airline TEXT,
-  callsign TEXT,
-  duration TEXT,
-  notes TEXT,
-  origin TEXT,
-  destination TEXT,
-  travelClass TEXT,
-  seatNumber TEXT,
-  seatLocation TEXT,
-  distanceKm REAL,
-  carbonKg REAL,
-  isFavorite INTEGER,
-  isBusiness INTEGER
-)''');
-      },
-    );
-    return _db!;
+    return AppDatabase.open();
   }
 
   static Future<List<Flight>> loadFlights() async {


### PR DESCRIPTION
## Summary
- add AppDatabase utility with migration for airports, airlines and aircraft
- add storage classes for airport, airline and aircraft data
- load reference data from the database at startup
- serialize aircraft, airline and airport models
- update existing code to use the new data stores

## Testing
- `flutter test` *(fails: `flutter: command not found`)*