### PR TITLE
Add centralized text theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'models/flight.dart';
 import 'models/flight_storage.dart';
@@ -15,6 +14,7 @@ import 'data/airport_data.dart';
 import 'data/airline_data.dart';
 import 'data/aircraft_data.dart';
 import 'theme/colors.dart';
+import 'theme/text_theme.dart';
 
 // Ensure text on the brand colors meets WCAG AA contrast ratio.
 // Using white text on the primary blue yields a contrast of about 5.12:1.
@@ -183,7 +183,7 @@ class _SkyBookAppState extends State<SkyBookApp> {
       title: 'SkyBook',
       theme: ThemeData(
         colorScheme: _lightColorScheme,
-        textTheme: GoogleFonts.robotoTextTheme(),
+        textTheme: AppTextTheme.light,
         dialogTheme: DialogThemeData(
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
@@ -194,7 +194,7 @@ class _SkyBookAppState extends State<SkyBookApp> {
       ),
       darkTheme: ThemeData(
         colorScheme: _darkColorScheme,
-        textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),
+        textTheme: AppTextTheme.dark,
         dialogTheme: DialogThemeData(
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -414,7 +414,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                           const Icon(Icons.flight, size: 32),
                     ),
                     const SizedBox(width: 8),
-                    Text('Airline: ${_selectedAirline!.name}'),
+                    Text(
+                      'Airline: ${_selectedAirline!.name}',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ],
                 ),
               ),
@@ -451,7 +454,10 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
             if (_distanceKm != null)
               Padding(
                 padding: const EdgeInsets.only(top: 8.0),
-                child: Text('Distance: ${_distanceKm!.round()} km'),
+                child: Text(
+                  'Distance: ${_distanceKm!.round()} km',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
               ),
           ],
         ),

--- a/lib/theme/text_theme.dart
+++ b/lib/theme/text_theme.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Application text themes used for both light and dark modes.
+class AppTextTheme {
+  AppTextTheme._();
+
+  static final TextTheme light = _buildTheme(ThemeData.light().textTheme);
+  static final TextTheme dark = _buildTheme(ThemeData.dark().textTheme);
+
+  static TextTheme _buildTheme(TextTheme base) {
+    final textTheme = GoogleFonts.robotoTextTheme(base);
+    return textTheme.copyWith(
+      headlineLarge: textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.bold),
+      headlineMedium: textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+      headlineSmall: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+      titleLarge: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+      titleMedium: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+      titleSmall: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+      labelLarge: textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w500),
+      labelMedium: textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w500),
+      labelSmall: textTheme.labelSmall?.copyWith(fontWeight: FontWeight.w500),
+    );
+  }
+}

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -114,7 +114,10 @@ class FlightTile extends StatelessWidget {
                   children: [
                     const Icon(Icons.schedule, size: 16),
                     const SizedBox(width: 4),
-                    Text('${flight.duration}h'),
+                    Text(
+                      '${flight.duration}h',
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
                   ],
                 ),
                 IconButton(

--- a/lib/widgets/skybook_app_bar.dart
+++ b/lib/widgets/skybook_app_bar.dart
@@ -28,6 +28,7 @@ class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
             child: Text(
               title,
               overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- create `AppTextTheme` with headline, title, body and label styles
- wire the new theme into the light and dark `ThemeData`
- apply themed styles to app bar title and flight info widgets

## Testing
- `dart format` *(fails: `dart` not found)*