### PR TITLE
Refactor navigation and cards

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -9,6 +9,7 @@ import '../data/airport_data.dart';
 import '../data/aircraft_data.dart';
 import '../data/airline_data.dart';
 import '../widgets/skybook_app_bar.dart';
+import '../widgets/skybook_card.dart';
 import '../utils/text_formatters.dart';
 import '../utils/carbon_utils.dart';
 import '../widgets/app_dialog.dart';
@@ -376,10 +377,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
     );
   }
   Widget _buildFlightInfoCard() {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.s),
-        child: Column(
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Flight Info',
@@ -429,10 +429,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   }
 
   Widget _buildRouteDetailsCard() {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.s),
-        child: Column(
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Route Details',
@@ -467,10 +466,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   }
 
   Widget _buildTravelDetailsCard() {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.s),
-        child: Column(
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Travel Details',
@@ -545,10 +543,9 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
   }
 
   Widget _buildNotesCard() {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.s),
-        child: Column(
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Notes', style: Theme.of(context).textTheme.titleMedium),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import 'map_screen.dart';
 import 'status_screen.dart';
 import 'progress_screen.dart';
 import 'settings_screen.dart';
+import '../widgets/skybook_bottom_nav_bar.dart';
 
 class HomeScreen extends StatefulWidget {
   final VoidCallback onToggleTheme;
@@ -98,34 +99,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     return Scaffold(
       body: IndexedStack(index: _selectedIndex, children: pages),
-      bottomNavigationBar: BottomNavigationBar(
+      bottomNavigationBar: SkyBookBottomNavBar(
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,
-        selectedItemColor: Theme.of(context).colorScheme.primary,
-        unselectedItemColor:
-            Theme.of(context).colorScheme.onSurfaceVariant,
-        items: [
-          BottomNavigationBarItem(
-            // icon: ImageIcon(const AssetImage('assets/icons/map.png')),
-            icon: const Icon(Icons.map),
-            label: 'Map',
-          ),
-          BottomNavigationBarItem(
-            // icon: ImageIcon(const AssetImage('assets/icons/flights.png')),
-            icon: const Icon(Icons.flight),
-            label: 'Flights',
-          ),
-          BottomNavigationBarItem(
-            // icon: ImageIcon(const AssetImage('assets/icons/progress.png')),
-            icon: const Icon(Icons.emoji_events),
-            label: 'Progress',
-          ),
-          BottomNavigationBarItem(
-            // icon: ImageIcon(const AssetImage('assets/icons/status.png')),
-            icon: const Icon(Icons.analytics),
-            label: 'Status',
-          ),
-        ],
       ),
     );
   }

--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/class_pie_chart.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/flight_line_chart.dart';
 import '../widgets/numeric_line_chart.dart';
+import '../widgets/skybook_card.dart';
 import '../constants.dart';
 
 class StatusScreen extends StatefulWidget {
@@ -400,12 +401,11 @@ class _StatusTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.s),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
             Icon(icon, size: 32, color: colors.primary),
             const SizedBox(height: 8),
             Text(
@@ -422,8 +422,7 @@ class _StatusTile extends StatelessWidget {
                   .bodyMedium
                   ?.copyWith(color: colors.onSurface),
             ),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/flight.dart';
 import '../constants.dart';
+import 'skybook_card.dart';
 
 class FlightTile extends StatelessWidget {
   final Flight flight;
@@ -46,19 +47,12 @@ class FlightTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return SkyBookCard(
       color: _colorForClass(context),
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
-      elevation: 2,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          child: Column(
+      padding: const EdgeInsets.all(AppSpacing.xs),
+      onTap: onTap,
+      child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
@@ -126,11 +120,10 @@ class FlightTile extends StatelessWidget {
                   onPressed: onEdit,
                 ),
               ],
-            )
+            ),
           ],
         ),
       ),
-    ),
     );
   }
 }

--- a/lib/widgets/skybook_app_bar.dart
+++ b/lib/widgets/skybook_app_bar.dart
@@ -4,12 +4,14 @@ class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final List<Widget>? actions;
   final PreferredSizeWidget? bottom;
+  final bool showLogo;
 
   const SkyBookAppBar({
     Key? key,
     required this.title,
     this.actions,
     this.bottom,
+    this.showLogo = true,
   }) : super(key: key);
 
   @override
@@ -22,8 +24,10 @@ class SkyBookAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       title: Row(
         children: [
-          Image.asset('assets/logo_r.png', height: kToolbarHeight - 16),
-          const SizedBox(width: 8),
+          if (showLogo) ...[
+            Image.asset('assets/logo_r.png', height: kToolbarHeight - 16),
+            const SizedBox(width: 8),
+          ],
           Expanded(
             child: Text(
               title,

--- a/lib/widgets/skybook_bottom_nav_bar.dart
+++ b/lib/widgets/skybook_bottom_nav_bar.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Bottom navigation bar used on the home screen.
+class SkyBookBottomNavBar extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  const SkyBookBottomNavBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: onTap,
+      type: BottomNavigationBarType.fixed,
+      selectedItemColor: colors.primary,
+      unselectedItemColor: colors.onSurfaceVariant,
+      items: const [
+        BottomNavigationBarItem(
+          icon: Icon(Icons.map),
+          label: 'Map',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.flight),
+          label: 'Flights',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.emoji_events),
+          label: 'Progress',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.analytics),
+          label: 'Status',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/skybook_card.dart
+++ b/lib/widgets/skybook_card.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../constants.dart';
+
+/// Common card used throughout the app with consistent styling.
+class SkyBookCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final Color? color;
+  final VoidCallback? onTap;
+  final double elevation;
+  final double borderRadius;
+
+  const SkyBookCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.margin,
+    this.color,
+    this.onTap,
+    this.elevation = 2,
+    this.borderRadius = 12,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Card(
+      color: color,
+      margin: margin ?? EdgeInsets.zero,
+      elevation: elevation,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(borderRadius),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: padding ?? const EdgeInsets.all(AppSpacing.s),
+        child: child,
+      ),
+    );
+
+    if (onTap != null) {
+      return InkWell(onTap: onTap, child: card);
+    }
+    return card;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `SkyBookCard` widget
- add `SkyBookBottomNavBar` component
- make `SkyBookAppBar` logo optional
- use the new card for flight tiles, status tiles and input forms
- swap `BottomNavigationBar` for `SkyBookBottomNavBar`

## Testing
- `No tests run - Flutter SDK not installed`