### PR TITLE
Add KPI home widget service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Developer section preference is saved so your choice is remembered
 - Unlock Premium mode in settings to view CO₂ data and detailed graphs
 - Premium users can quickly add flights via a home screen shortcut
+- View key stats from a home screen widget on iOS and Android
 - Data is stored locally on the device
 - View your routes on an interactive map
 - Quickly access Map, Flights, Progress and Status using the bottom navigation bar

--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -1,0 +1,51 @@
+import 'package:home_widget/home_widget.dart';
+
+import '../models/flight.dart';
+
+/// Simple data holder for aggregated totals shown in the widget.
+class KpiTotals {
+  final int flights;
+  final double distanceKm;
+  final double carbonKg;
+
+  const KpiTotals({
+    required this.flights,
+    required this.distanceKm,
+    required this.carbonKg,
+  });
+}
+
+class WidgetService {
+  /// Aggregates totals from a list of flights.
+  static KpiTotals aggregate(List<Flight> flights) {
+    final totalFlights = flights.length;
+    final totalDistance = flights.fold<double>(
+      0,
+      (sum, f) => sum + (f.distanceKm.isNaN ? 0 : f.distanceKm),
+    );
+    final totalCarbon = flights.fold<double>(
+      0,
+      (sum, f) => sum + (f.carbonKg.isNaN ? 0 : f.carbonKg),
+    );
+    return KpiTotals(
+      flights: totalFlights,
+      distanceKm: totalDistance,
+      carbonKg: totalCarbon,
+    );
+  }
+
+  /// Writes aggregated flight data to the native widget and triggers a refresh.
+  static Future<void> updateKpiWidget(List<Flight> flights) async {
+    final totals = aggregate(flights);
+
+    await HomeWidget.saveWidgetData<int>('totalFlights', totals.flights);
+    await HomeWidget.saveWidgetData<double>('totalDistance', totals.distanceKm);
+    await HomeWidget.saveWidgetData<double>('totalCarbon', totals.carbonKg);
+
+    // These names must correspond to the platform specific widget providers.
+    await HomeWidget.updateWidget(
+      name: 'HomeKpiWidgetProvider',
+      iOSName: 'SkyBookWidget',
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   intl: ^0.18.0
   share_plus: ^6.3.0
   quick_actions: ^1.0.0
+  home_widget: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_service_test.dart
+++ b/test/widget_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skybook/services/widget_service.dart';
+import 'package:skybook/models/flight.dart';
+
+Flight _flight(double distance, double carbon) {
+  return Flight(
+    id: '1',
+    date: '2023-01-01',
+    aircraft: 'Boeing 737',
+    manufacturer: 'Boeing',
+    airline: '',
+    callsign: '',
+    duration: '',
+    notes: '',
+    origin: '',
+    destination: '',
+    travelClass: '',
+    seatNumber: '',
+    seatLocation: '',
+    distanceKm: distance,
+    carbonKg: carbon,
+  );
+}
+
+void main() {
+  test('aggregate totals sums distance and carbon', () {
+    final flights = [
+      _flight(1000, 50),
+      _flight(2000, 75),
+    ];
+
+    final totals = WidgetService.aggregate(flights);
+
+    expect(totals.flights, 2);
+    expect(totals.distanceKm, 3000);
+    expect(totals.carbonKg, 125);
+  });
+}


### PR DESCRIPTION
## Summary
- add `home_widget` package
- document the new home screen widget
- provide `WidgetService` for updating KPI widget
- test the aggregation logic for the widget

## Testing
- `flutter test` *(fails: `flutter: command not found`)*