### PR TITLE
Restrict widget to premium

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - Developer section preference is saved so your choice is remembered
 - Unlock Premium mode in settings to view CO₂ data and detailed graphs
 - Premium users can quickly add flights via a home screen shortcut
-- View key stats from a home screen widget on iOS and Android
+- Premium users can view key stats from a home screen widget on iOS and Android
 - Data is stored locally on the device
 - View your routes on an interactive map
 - Quickly access Map, Flights, Progress and Status using the bottom navigation bar

--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -1,6 +1,7 @@
 import 'package:home_widget/home_widget.dart';
 
 import '../models/flight.dart';
+import '../models/premium_storage.dart';
 
 /// Simple data holder for aggregated totals shown in the widget.
 class KpiTotals {
@@ -36,6 +37,9 @@ class WidgetService {
 
   /// Writes aggregated flight data to the native widget and triggers a refresh.
   static Future<void> updateKpiWidget(List<Flight> flights) async {
+    final premium = await PremiumStorage.loadPremium();
+    if (!premium) return;
+
     final totals = aggregate(flights);
 
     await HomeWidget.saveWidgetData<int>('totalFlights', totals.flights);


### PR DESCRIPTION
## Summary
- block home screen widget updates when not premium
- document that the widget is a premium feature

## Testing
- `flutter test` *(fails: command not found)*