### PR TITLE
Fix iOS build issue by pinning home_widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
    ```sh
    flutter pub get
    ```
+   The `home_widget` package is pinned to version `0.5.0`. If this version is
+   upgraded, iOS builds may fail due to the missing
+   `WidgetConfigurationIntent` definition required by newer releases.
 3. Run the app:
    ```sh
    flutter run

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,9 @@ dependencies:
   intl: ^0.18.0
   share_plus: ^6.3.0
   quick_actions: ^1.0.0
-  home_widget: ^0.5.0
+  # Pin the version to avoid breaking iOS builds due to the new
+  # WidgetConfigurationIntent requirement in v0.8.0+.
+  home_widget: 0.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- pin the `home_widget` package to version 0.5.0
- warn about newer `home_widget` versions in the README

## Testing
- `dart`/`flutter` unavailable