### PR TITLE
Enforce uppercase in flight number field

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -413,6 +413,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
         labelText: 'Flight Number',
         prefixIcon: Icon(Icons.flight, semanticLabel: 'Flight number'),
       ),
+      inputFormatters: [UpperCaseTextFormatter()],
       onChanged: _updateAirline,
     );
   }


### PR DESCRIPTION
## Summary
- ensure that the flight number is always entered in capital letters by applying `UpperCaseTextFormatter` in `AddFlightScreen`

## Testing
- `flutter test` *(fails: `flutter` not found)*