### PR TITLE
Apply Duolingo‑style theme

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -8,9 +8,9 @@ The color palette is defined in `lib/theme/colors.dart`.
 
 | Token | Light | Dark | Description |
 |-------|-------|------|-------------|
-| `primary` | `0xFF0A73B1` | `primaryDark` | Brand blue used for the app bar and primary actions. |
-| `secondary` | `0xFFEF6C00` | `secondaryDark` | Accent orange for highlights and buttons. |
-| `accent` | `0xFF009688` | `accentDark` | Optional accent color used sparingly for emphasis. |
+| `primary` | `0xFF58CC02` | `primaryDark` | Bright green used for major actions. |
+| `secondary` | `0xFFFFC107` | `secondaryDark` | Yellow accent for highlights and buttons. |
+| `accent` | `0xFF34A853` | `accentDark` | Deeper green used sparingly for emphasis. |
 
 Use `primaryLight`, `secondaryLight`, and `accentLight` for subtle variants.
 
@@ -32,7 +32,7 @@ These tokens are used for padding and layout gaps to keep the interface consiste
 
 ## Typography
 
-Font styles are created in `lib/theme/text_theme.dart` using the Roboto font via Google Fonts. The bold and semi‑bold weights are applied to headings and titles to maintain hierarchy.
+Font styles are created in `lib/theme/text_theme.dart` using the Nunito font via Google Fonts. The bold and semi‑bold weights are applied to headings and titles to maintain hierarchy.
 
 When creating new text styles, start from `AppTextTheme.light` or `AppTextTheme.dark` to ensure proper scaling and accessibility.
 

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -3,17 +3,17 @@ import 'package:flutter/material.dart';
 /// Defines the application color palette.
 class AppColors {
   // Primary brand color
-  static const Color primary = Color(0xFF0A73B1);
-  static const Color primaryLight = Color(0xFF5AA7D5);
-  static const Color primaryDark = Color(0xFF084B75);
+  static const Color primary = Color(0xFF58CC02); // Duolingo green
+  static const Color primaryLight = Color(0xFF8FEA57);
+  static const Color primaryDark = Color(0xFF389704);
 
   // Secondary brand color
-  static const Color secondary = Color(0xFFEF6C00);
-  static const Color secondaryLight = Color(0xFFFFA04E);
-  static const Color secondaryDark = Color(0xFFB25100);
+  static const Color secondary = Color(0xFFFFC107); // warm yellow accent
+  static const Color secondaryLight = Color(0xFFFFE082);
+  static const Color secondaryDark = Color(0xFFB28704);
 
   // Accent color used for highlights
-  static const Color accent = Color(0xFF009688);
-  static const Color accentLight = Color(0xFF52C7B8);
-  static const Color accentDark = Color(0xFF00675B);
+  static const Color accent = Color(0xFF34A853); // darker green for emphasis
+  static const Color accentLight = Color(0xFF6BD079);
+  static const Color accentDark = Color(0xFF0B7728);
 }

--- a/lib/theme/text_theme.dart
+++ b/lib/theme/text_theme.dart
@@ -9,7 +9,8 @@ class AppTextTheme {
   static final TextTheme dark = _buildTheme(ThemeData.dark().textTheme);
 
   static TextTheme _buildTheme(TextTheme base) {
-    final textTheme = GoogleFonts.robotoTextTheme(base);
+    // Use a friendlier font to match Duolingo's style
+    final textTheme = GoogleFonts.nunitoTextTheme(base);
     return textTheme.copyWith(
       headlineLarge: textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.bold),
       headlineMedium: textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),


### PR DESCRIPTION
## Summary
- switch primary color scheme to bright greens and yellow accent
- use Nunito Google Font for a playful style
- document new colors and typography in the style guide

## Testing
- `flutter test` *(fails: `flutter: command not found`)*
- `dart format lib/theme/colors.dart lib/theme/text_theme.dart` *(fails: `dart: command not found`)*