### PR TITLE
Revert to original blue palette

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -8,9 +8,9 @@ The color palette is defined in `lib/theme/colors.dart`.
 
 | Token | Light | Dark | Description |
 |-------|-------|------|-------------|
-| `primary` | `0xFF58CC02` | `primaryDark` | Bright green used for major actions. |
-| `secondary` | `0xFFFFC107` | `secondaryDark` | Yellow accent for highlights and buttons. |
-| `accent` | `0xFF34A853` | `accentDark` | Deeper green used sparingly for emphasis. |
+| `primary` | `0xFF0A73B1` | `primaryDark` | Brand blue used for the app bar and primary actions. |
+| `secondary` | `0xFFEF6C00` | `secondaryDark` | Accent orange for highlights and buttons. |
+| `accent` | `0xFF009688` | `accentDark` | Optional accent color used sparingly for emphasis. |
 
 Use `primaryLight`, `secondaryLight`, and `accentLight` for subtle variants.
 

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -3,17 +3,17 @@ import 'package:flutter/material.dart';
 /// Defines the application color palette.
 class AppColors {
   // Primary brand color
-  static const Color primary = Color(0xFF58CC02); // Duolingo green
-  static const Color primaryLight = Color(0xFF8FEA57);
-  static const Color primaryDark = Color(0xFF389704);
+  static const Color primary = Color(0xFF0A73B1);
+  static const Color primaryLight = Color(0xFF5AA7D5);
+  static const Color primaryDark = Color(0xFF084B75);
 
   // Secondary brand color
-  static const Color secondary = Color(0xFFFFC107); // warm yellow accent
-  static const Color secondaryLight = Color(0xFFFFE082);
-  static const Color secondaryDark = Color(0xFFB28704);
+  static const Color secondary = Color(0xFFEF6C00);
+  static const Color secondaryLight = Color(0xFFFFA04E);
+  static const Color secondaryDark = Color(0xFFB25100);
 
   // Accent color used for highlights
-  static const Color accent = Color(0xFF34A853); // darker green for emphasis
-  static const Color accentLight = Color(0xFF6BD079);
-  static const Color accentDark = Color(0xFF0B7728);
+  static const Color accent = Color(0xFF009688);
+  static const Color accentLight = Color(0xFF52C7B8);
+  static const Color accentDark = Color(0xFF00675B);
 }


### PR DESCRIPTION
## Summary
- restore the initial blue/orange color palette in `AppColors`
- update style guide to document the original colors

## Testing
- `git log -1 --stat`