### PR TITLE
Update README with iOS Podfile tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
    ```sh
    flutter pub get
    ```
-   The `home_widget` package is pinned to version `0.5.0`. If this version is
-   upgraded, iOS builds may fail due to the missing
-   `WidgetConfigurationIntent` definition required by newer releases.
-3. Run the app:
+   Ensure the `home_widget` package is kept at version `0.5.0` in
+   `pubspec.yaml`. If this version is upgraded, iOS builds may fail due to the
+   missing `WidgetConfigurationIntent` definition required by newer releases.
+3. In `ios/Podfile`, uncomment the `platform :ios` line and set the version to
+   `15.5` so the app builds correctly.
+4. Run the app:
    ```sh
    flutter run
    ```


### PR DESCRIPTION
## Summary
- clarify that `home_widget` must remain at version `0.5.0`
- add instruction to set the iOS Podfile platform version to 15.5

## Testing
- `flutter --version` *(fails: command not found)*