### PR TITLE
Fix missing cupertino icons fonts

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  cupertino_icons: ^1.0.5
   shared_preferences: ^2.2.0
   sqflite: ^2.3.0
   path: ^1.8.3


### PR DESCRIPTION
## Summary
- include `cupertino_icons` package so Cupertino icon fonts are bundled

## Testing
- `flutter --version` *(fails: command not found)*