### PR TITLE
Remove boarding pass scanning feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 
 - Add flights with date, aircraft, duration and optional notes
 - Enter the flight number and the airline will be detected automatically
-- Prefill details by scanning a boarding pass or importing itinerary text
+<!-- - Prefill details by scanning a boarding pass or importing itinerary text -->
 - View a list of all recorded flights
 - View overall stats like total flights and hours
 - See your top airlines in the Status section

--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:image_picker/image_picker.dart';
+// import 'package:image_picker/image_picker.dart';
 import '../models/flight.dart';
 import '../models/aircraft.dart';
 import '../models/airport.dart';
@@ -192,6 +192,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
     }
   }
 
+  /*
   Future<void> _scanBoardingPass() async {
     final picker = ImagePicker();
     final picked = await picker.pickImage(source: ImageSource.camera);
@@ -213,6 +214,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
     _updateAirline(flight.callsign);
     _computeDistance();
   }
+  */
 
   Future<void> _importItinerary() async {
     final text = await showDialog<String>(
@@ -539,6 +541,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
             const SizedBox(height: 8),
             Row(
               children: [
+                /*
                 Expanded(
                   child: ElevatedButton.icon(
                     onPressed: _scanBoardingPass,
@@ -547,6 +550,7 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                   ),
                 ),
                 const SizedBox(width: 8),
+                */
                 Expanded(
                   child: ElevatedButton.icon(
                     onPressed: _importItinerary,

--- a/lib/services/import_service.dart
+++ b/lib/services/import_service.dart
@@ -1,9 +1,10 @@
-import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+// import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
 import '../models/flight.dart';
 
 /// Provides utilities for importing flight details from external sources.
 class ImportService {
+  /*
   /// Runs text recognition on the image at [path] and attempts to parse flight
   /// details from the recognized text. Returns a [Flight] with any discovered
   /// fields or `null` if parsing failed.
@@ -14,6 +15,7 @@ class ImportService {
     recognizer.close();
     return _parse(result.text);
   }
+  */
 
   /// Attempts to parse flight details from plain text, such as an itinerary
   /// email. Returns a [Flight] with any discovered fields or `null` if parsing


### PR DESCRIPTION
## Summary
- comment out the boarding pass scanning feature in the add flight screen
- disable the corresponding import service method
- hide bullet about scanning from README

## Testing
- `flutter test` *(fails: `flutter` command not found)*