### PR TITLE
Fix map zoom for flight details

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -49,7 +49,9 @@ class FlightDetailScreen extends StatelessWidget {
     final start = LatLng(origin.latitude, origin.longitude);
     final end = LatLng(dest.latitude, dest.longitude);
     final routePoints = MapUtils.arcPoints(start, end);
-    final view = MapUtils.viewForPoints(routePoints);
+    final width = MediaQuery.of(context).size.width - AppSpacing.s * 2;
+    const height = 200.0;
+    final view = MapUtils.viewForPointsInSize(routePoints, width, height);
     final center = view.center;
     final zoom = view.zoom;
 

--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -86,6 +86,64 @@ class MapUtils {
 
     return MapView(center: center, zoom: zoom);
   }
+
+  /// Calculates the map [center] and [zoom] that ensure [points] are visible
+  /// within a widget of size [width] x [height]. This accounts for the aspect
+  /// ratio so markers near the edges aren't clipped.
+  static MapView viewForPointsInSize(
+    List<LatLng> points,
+    double width,
+    double height, {
+    double minZoom = 2.0,
+    double maxZoom = 16.0,
+  }) {
+    if (points.isEmpty || width <= 0 || height <= 0) {
+      return viewForPoints(points, minZoom: minZoom, maxZoom: maxZoom);
+    }
+
+    double minLat = points.first.latitude;
+    double maxLat = points.first.latitude;
+    double minLon = points.first.longitude;
+    double maxLon = points.first.longitude;
+    for (final p in points) {
+      if (p.latitude < minLat) minLat = p.latitude;
+      if (p.latitude > maxLat) maxLat = p.latitude;
+      if (p.longitude < minLon) minLon = p.longitude;
+      if (p.longitude > maxLon) maxLon = p.longitude;
+    }
+
+    double diffLon = (maxLon - minLon).abs();
+    double centerLon;
+    if (diffLon > 180) {
+      diffLon = 360 - diffLon;
+      centerLon = (minLon + maxLon + 360) / 2;
+      if (centerLon > 180) centerLon -= 360;
+    } else {
+      centerLon = (minLon + maxLon) / 2;
+    }
+
+    final center = LatLng((minLat + maxLat) / 2, centerLon);
+
+    // Convert latitude to Mercator Y to correctly account for the projection
+    double _latToY(double lat) =>
+        math.log(math.tan((lat + 90) * math.pi / 360));
+
+    final north = _latToY(maxLat);
+    final south = _latToY(minLat);
+    final diffY = (north - south).abs();
+
+    // Base tile size in pixels used by flutter_map / web mercator
+    const worldDim = 256.0;
+
+    final zoomX = math.log((width * 360) / (diffLon * worldDim)) / math.ln2;
+    final zoomY = math.log((height * 2 * math.pi) / (diffY * worldDim)) / math.ln2;
+
+    var zoom = math.min(zoomX, zoomY);
+    if (zoom.isNaN || zoom.isInfinite) zoom = 3;
+    zoom = zoom.clamp(minZoom, maxZoom);
+
+    return MapView(center: center, zoom: zoom);
+  }
 }
 
 /// Simple holder for a map's center point and zoom level.


### PR DESCRIPTION
## Summary
- ensure both airports are visible on the flight details map
- add helper to calculate map zoom/center with widget size

## Testing
- `flutter test` *(fails: flutter not installed)*