### PR TITLE
Add boarding pass scanning

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
-// import 'package:image_picker/image_picker.dart';
+import 'package:image_picker/image_picker.dart';
 import '../models/flight.dart';
 import '../models/aircraft.dart';
 import '../models/airport.dart';
@@ -192,7 +192,6 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
     }
   }
 
-  /*
   Future<void> _scanBoardingPass() async {
     final picker = ImagePicker();
     final picked = await picker.pickImage(source: ImageSource.camera);
@@ -214,7 +213,6 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
     _updateAirline(flight.callsign);
     _computeDistance();
   }
-  */
 
   Future<void> _importItinerary() async {
     final text = await showDialog<String>(
@@ -541,7 +539,6 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
             const SizedBox(height: 8),
             Row(
               children: [
-                /*
                 Expanded(
                   child: ElevatedButton.icon(
                     onPressed: _scanBoardingPass,
@@ -550,7 +547,6 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
                   ),
                 ),
                 const SizedBox(width: 8),
-                */
                 Expanded(
                   child: ElevatedButton.icon(
                     onPressed: _importItinerary,

--- a/lib/services/import_service.dart
+++ b/lib/services/import_service.dart
@@ -1,27 +1,41 @@
-// import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
+import 'package:google_mlkit_commons/google_mlkit_commons.dart';
 
 import '../models/flight.dart';
 
 /// Provides utilities for importing flight details from external sources.
 class ImportService {
-  /*
-  /// Runs text recognition on the image at [path] and attempts to parse flight
-  /// details from the recognized text. Returns a [Flight] with any discovered
-  /// fields or `null` if parsing failed.
+  /// Scans the image at [path] for a barcode or QR code and attempts to
+  /// extract flight details. Returns a [Flight] with any discovered fields or
+  /// `null` if parsing failed.
   static Future<Flight?> scanBoardingPassImage(String path) async {
     final inputImage = InputImage.fromFilePath(path);
-    final recognizer = TextRecognizer(script: TextRecognitionScript.latin);
-    final result = await recognizer.processImage(inputImage);
-    recognizer.close();
-    return _parse(result.text);
+    final scanner = BarcodeScanner(formats: [
+      BarcodeFormat.qrCode,
+      BarcodeFormat.pdf417,
+    ]);
+    final barcodes = await scanner.processImage(inputImage);
+    scanner.close();
+
+    for (final barcode in barcodes) {
+      final raw = barcode.rawValue;
+      if (raw == null || raw.isEmpty) continue;
+      final flight = parseBarcodeData(raw);
+      if (flight != null) return flight;
+    }
+    return null;
   }
-  */
 
   /// Attempts to parse flight details from plain text, such as an itinerary
   /// email. Returns a [Flight] with any discovered fields or `null` if parsing
   /// failed.
   static Flight? parseItineraryText(String text) {
     return _parse(text);
+  }
+
+  /// Attempts to parse flight information from raw barcode or QR code data.
+  static Flight? parseBarcodeData(String data) {
+    return _parse(data);
   }
 
   /// Extracts a flight number, origin, destination and optional date from

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   home_widget: 0.5.0
   image_picker: ^1.0.4
   google_mlkit_text_recognition: ^0.11.0
+  google_mlkit_barcode_scanning: ^0.11.0
 
 dev_dependencies:
   flutter_test:

--- a/test/import_service_test.dart
+++ b/test/import_service_test.dart
@@ -18,5 +18,20 @@ void main() {
       final flight = ImportService.parseItineraryText(text);
       expect(flight, isNull);
     });
+
+    test('parse barcode data', () {
+      const data = 'M1DOE/JANE           AA123 JFK LAX 2024-02-01';
+      final flight = ImportService.parseBarcodeData(data);
+      expect(flight, isNotNull);
+      expect(flight!.callsign, 'AA123');
+      expect(flight.origin, 'JFK');
+      expect(flight.destination, 'LAX');
+    });
+
+    test('invalid barcode returns null', () {
+      const data = 'HELLO WORLD';
+      final flight = ImportService.parseBarcodeData(data);
+      expect(flight, isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- enable camera boarding pass scanning on Add Flight screen
- support parsing flight info from barcode data
- add barcode scanning dependency
- test barcode parsing

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*