### PR TITLE
Add wallet pass import service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 
 - Add flights with date, aircraft, duration and optional notes
 - Enter the flight number and the airline will be detected automatically
-<!-- - Prefill details by scanning a boarding pass or importing itinerary text -->
+- Import flight details from a boarding pass stored in Apple Wallet
 - View a list of all recorded flights
 - View overall stats like total flights and hours
 - See your top airlines in the Status section

--- a/lib/services/wallet_service.dart
+++ b/lib/services/wallet_service.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/services.dart';
+
+import '../models/flight.dart';
+import 'import_service.dart';
+
+/// Provides integration with Apple Wallet to import boarding passes.
+class WalletService {
+  static const MethodChannel _channel = MethodChannel('skybook/wallet');
+
+  /// Retrieves the raw boarding pass data from Apple Wallet via a platform
+  /// channel and parses it into a [Flight]. Returns `null` if no pass was
+  /// retrieved or parsing failed.
+  static Future<Flight?> importFromWallet() async {
+    try {
+      final data = await _channel.invokeMethod<String>('getBoardingPass');
+      if (data == null || data.isEmpty) return null;
+      return ImportService.parseBarcodeData(data);
+    } on PlatformException {
+      return null;
+    }
+  }
+}

--- a/test/wallet_service_test.dart
+++ b/test/wallet_service_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skybook/services/wallet_service.dart';
+
+void main() {
+  const channel = MethodChannel('skybook/wallet');
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      if (methodCall.method == 'getBoardingPass') {
+        return 'M1DOE/JANE           AA123 JFK LAX 2024-02-01';
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('importFromWallet parses flight from wallet data', () async {
+    final flight = await WalletService.importFromWallet();
+    expect(flight, isNotNull);
+    expect(flight!.callsign, 'AA123');
+    expect(flight.origin, 'JFK');
+    expect(flight.destination, 'LAX');
+  });
+}


### PR DESCRIPTION
## Summary
- integrate Apple Wallet with a new service
- show feature in README
- test wallet service with mocked MethodChannel

## Testing
- `flutter test` *(fails: command not found)*