### PR TITLE
Add status widget aggregation

### DIFF
--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -16,6 +16,25 @@ class KpiTotals {
   });
 }
 
+/// Data holder for the values displayed in the medium status widget.
+class StatusTotals {
+  final int flights;
+  final double durationHours;
+  final double carbonKg;
+  final String favoritePlane;
+  final String favoriteAirline;
+  final String favoriteDestination;
+
+  const StatusTotals({
+    required this.flights,
+    required this.durationHours,
+    required this.carbonKg,
+    required this.favoritePlane,
+    required this.favoriteAirline,
+    required this.favoriteDestination,
+  });
+}
+
 class WidgetService {
   /// Aggregates totals from a list of flights.
   static KpiTotals aggregate(List<Flight> flights) {
@@ -35,6 +54,50 @@ class WidgetService {
     );
   }
 
+  /// Data holder for the values shown on the medium status widget.
+  static String _topKey(Map<String, int> counts) {
+    if (counts.isEmpty) return 'N/A';
+    return counts.entries
+        .reduce((a, b) => a.value >= b.value ? a : b)
+        .key;
+  }
+
+  /// Aggregates the metrics displayed in the status tiles.
+  static StatusTotals aggregateStatus(List<Flight> flights) {
+    final totalFlights = flights.length;
+    final totalDuration = flights.fold<double>(
+      0,
+      (sum, f) => sum + (double.tryParse(f.duration) ?? 0),
+    );
+    final totalCarbon = flights.fold<double>(
+      0,
+      (sum, f) => sum + (f.carbonKg.isNaN ? 0 : f.carbonKg),
+    );
+
+    final aircraftCounts = <String, int>{};
+    final airlineCounts = <String, int>{};
+    final destCounts = <String, int>{};
+
+    for (final f in flights) {
+      aircraftCounts[f.aircraft] = (aircraftCounts[f.aircraft] ?? 0) + 1;
+      if (f.airline.isNotEmpty) {
+        airlineCounts[f.airline] = (airlineCounts[f.airline] ?? 0) + 1;
+      }
+      if (f.destination.isNotEmpty) {
+        destCounts[f.destination] = (destCounts[f.destination] ?? 0) + 1;
+      }
+    }
+
+    return StatusTotals(
+      flights: totalFlights,
+      durationHours: totalDuration,
+      carbonKg: totalCarbon,
+      favoritePlane: _topKey(aircraftCounts),
+      favoriteAirline: _topKey(airlineCounts),
+      favoriteDestination: _topKey(destCounts),
+    );
+  }
+
   /// Writes aggregated flight data to the native widget and triggers a refresh.
   static Future<void> updateKpiWidget(List<Flight> flights) async {
     final premium = await PremiumStorage.loadPremium();
@@ -50,6 +113,26 @@ class WidgetService {
     await HomeWidget.updateWidget(
       name: 'HomeKpiWidgetProvider',
       iOSName: 'SkyBookWidget',
+    );
+  }
+
+  /// Writes status tile data to the medium home widget and refreshes it.
+  static Future<void> updateStatusWidget(List<Flight> flights) async {
+    final premium = await PremiumStorage.loadPremium();
+    if (!premium) return;
+
+    final totals = aggregateStatus(flights);
+
+    await HomeWidget.saveWidgetData<int>('statusFlights', totals.flights);
+    await HomeWidget.saveWidgetData<double>('statusDuration', totals.durationHours);
+    await HomeWidget.saveWidgetData<double>('statusCarbon', totals.carbonKg);
+    await HomeWidget.saveWidgetData<String>('statusFavoritePlane', totals.favoritePlane);
+    await HomeWidget.saveWidgetData<String>('statusFavoriteAirline', totals.favoriteAirline);
+    await HomeWidget.saveWidgetData<String>('statusFavoriteDestination', totals.favoriteDestination);
+
+    await HomeWidget.updateWidget(
+      name: 'HomeStatusWidgetProvider',
+      iOSName: 'SkyBookStatusWidget',
     );
   }
 }

--- a/test/widget_service_test.dart
+++ b/test/widget_service_test.dart
@@ -2,18 +2,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:skybook/services/widget_service.dart';
 import 'package:skybook/models/flight.dart';
 
-Flight _flight(double distance, double carbon) {
+Flight _flight({
+  required String aircraft,
+  required String airline,
+  required String destination,
+  required String duration,
+  double distance = 0,
+  double carbon = 0,
+}) {
   return Flight(
     id: '1',
     date: '2023-01-01',
-    aircraft: 'Boeing 737',
-    manufacturer: 'Boeing',
-    airline: '',
+    aircraft: aircraft,
+    manufacturer: '',
+    airline: airline,
     callsign: '',
-    duration: '',
+    duration: duration,
     notes: '',
     origin: '',
-    destination: '',
+    destination: destination,
     travelClass: '',
     seatNumber: '',
     seatLocation: '',
@@ -28,8 +35,22 @@ Flight _flight(double distance, double carbon) {
 void main() {
   test('aggregate totals sums distance and carbon', () {
     final flights = [
-      _flight(1000, 50),
-      _flight(2000, 75),
+      _flight(
+        aircraft: 'Boeing 737',
+        airline: 'Delta',
+        destination: 'JFK',
+        duration: '1',
+        distance: 1000,
+        carbon: 50,
+      ),
+      _flight(
+        aircraft: 'Airbus A320',
+        airline: 'Delta',
+        destination: 'LAX',
+        duration: '2',
+        distance: 2000,
+        carbon: 75,
+      ),
     ];
 
     final totals = WidgetService.aggregate(flights);
@@ -37,5 +58,43 @@ void main() {
     expect(totals.flights, 2);
     expect(totals.distanceKm, 3000);
     expect(totals.carbonKg, 125);
+  });
+
+  test('aggregateStatus returns favorite metrics', () {
+    final flights = [
+      _flight(
+        aircraft: 'Boeing 737',
+        airline: 'Delta',
+        destination: 'LAX',
+        duration: '2',
+        distance: 1000,
+        carbon: 10,
+      ),
+      _flight(
+        aircraft: 'Airbus A320',
+        airline: 'United',
+        destination: 'JFK',
+        duration: '3',
+        distance: 2000,
+        carbon: 20,
+      ),
+      _flight(
+        aircraft: 'Boeing 737',
+        airline: 'Delta',
+        destination: 'LAX',
+        duration: '1',
+        distance: 500,
+        carbon: 15,
+      ),
+    ];
+
+    final totals = WidgetService.aggregateStatus(flights);
+
+    expect(totals.flights, 3);
+    expect(totals.durationHours, closeTo(6, 0.001));
+    expect(totals.carbonKg, 45);
+    expect(totals.favoritePlane, 'Boeing 737');
+    expect(totals.favoriteAirline, 'Delta');
+    expect(totals.favoriteDestination, 'LAX');
   });
 }


### PR DESCRIPTION
## Summary
- add `StatusTotals` data class and aggregator logic in `WidgetService`
- add `updateStatusWidget` to send values to the new medium widget
- extend widget service tests for status aggregation

## Testing
- `flutter test` *(fails: `flutter` not installed)*