### PR TITLE
Fix TextDirection naming conflict

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -4,7 +4,7 @@ import '../models/flight.dart';
 import '../models/flight_storage.dart';
 import '../utils/achievement_utils.dart';
 import '../models/achievement.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 import '../widgets/skybook_app_bar.dart';
 import 'package:share_plus/share_plus.dart';
 import '../widgets/app_dialog.dart';
@@ -275,7 +275,7 @@ class _ProgressScreenState extends State<ProgressScreen>
                             style: Theme.of(context).textTheme.bodyMedium),
                         if (a.unlockedAt != null)
                           Text(
-                            DateFormat.yMMMd().format(a.unlockedAt!),
+                            intl.DateFormat.yMMMd().format(a.unlockedAt!),
                             style: Theme.of(context).textTheme.labelSmall,
                           ),
                         const SizedBox(height: 2),

--- a/lib/widgets/flight_line_chart.dart
+++ b/lib/widgets/flight_line_chart.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 class FlightLineChart extends StatelessWidget {
   final Map<DateTime, int> counts;
@@ -13,7 +13,7 @@ class FlightLineChart extends StatelessWidget {
     if (counts.isEmpty) return const SizedBox.shrink();
     final sortedKeys = counts.keys.toList()..sort();
     final data = [for (final k in sortedKeys) counts[k] ?? 0];
-    final labels = [for (final k in sortedKeys) DateFormat.yMMM().format(k)];
+    final labels = [for (final k in sortedKeys) intl.DateFormat.yMMM().format(k)];
     final lineColor = Theme.of(context).colorScheme.primary;
 
     return Column(

--- a/lib/widgets/numeric_line_chart.dart
+++ b/lib/widgets/numeric_line_chart.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 /// Line chart widget for numeric data keyed by month.
 class NumericLineChart extends StatelessWidget {
@@ -14,7 +14,7 @@ class NumericLineChart extends StatelessWidget {
     if (values.isEmpty) return const SizedBox.shrink();
     final sortedKeys = values.keys.toList()..sort();
     final data = [for (final k in sortedKeys) values[k]?.toDouble() ?? 0];
-    final labels = [for (final k in sortedKeys) DateFormat.yMMM().format(k)];
+    final labels = [for (final k in sortedKeys) intl.DateFormat.yMMM().format(k)];
     final lineColor = Theme.of(context).colorScheme.primary;
 
     return Column(


### PR DESCRIPTION
## Summary
- avoid `intl` `TextDirection` name clash by aliasing imports
- use alias `intl` to access `DateFormat`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*