### PR TITLE
Fix status tile text alignment

### DIFF
--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -655,6 +655,7 @@ class _StatusTile extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               value,
+              textAlign: TextAlign.center,
               style: Theme.of(context)
                   .textTheme
                   .titleMedium
@@ -662,6 +663,7 @@ class _StatusTile extends StatelessWidget {
             ),
             Text(
               label,
+              textAlign: TextAlign.center,
               style: Theme.of(context)
                   .textTheme
                   .bodySmall


### PR DESCRIPTION
## Summary
- center text within status tiles so values and labels align properly

## Testing
- `flutter test` *(fails: `flutter: command not found`)*