### PR TITLE
Show airport city and rotate plane icon

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -130,6 +130,9 @@ class FlightDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final originAirport = airportByCode[flight.origin];
+    final destAirport = airportByCode[flight.destination];
+
     final items = <Widget>[
       _buildMap(context),
       const SizedBox(height: 16),
@@ -140,6 +143,7 @@ class FlightDetailScreen extends StatelessWidget {
             child: InfoRow(
               title: 'From',
               value: flight.origin,
+              subtitle: originAirport?.city ?? '',
               icon: Icons.flight_takeoff,
             ),
           ),
@@ -148,6 +152,7 @@ class FlightDetailScreen extends StatelessWidget {
             child: InfoRow(
               title: 'To',
               value: flight.destination,
+              subtitle: destAirport?.city ?? '',
               icon: Icons.flight_land,
             ),
           ),

--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -129,7 +129,10 @@ class FlightTile extends StatelessWidget {
                         ),
                       Row(
                         children: const [
-                          Icon(Icons.flight, size: 20),
+                          RotatedBox(
+                            quarterTurns: 1,
+                            child: Icon(Icons.flight, size: 20),
+                          ),
                           Expanded(child: Divider(thickness: 1)),
                           Icon(Icons.circle, size: 8),
                         ],

--- a/lib/widgets/info_row.dart
+++ b/lib/widgets/info_row.dart
@@ -4,12 +4,14 @@ import '../constants.dart';
 class InfoRow extends StatelessWidget {
   final String title;
   final String value;
+  final String? subtitle;
   final IconData? icon;
 
   const InfoRow({
     super.key,
     required this.title,
     required this.value,
+    this.subtitle,
     this.icon,
   });
 
@@ -32,6 +34,10 @@ class InfoRow extends StatelessWidget {
             Text(title, style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 2),
             Text(value, style: Theme.of(context).textTheme.bodyMedium),
+            if (subtitle != null && subtitle!.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text(subtitle!, style: Theme.of(context).textTheme.bodySmall),
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add `subtitle` support to `InfoRow`
- rotate plane icon in flight tile
- show city next to airport code on flight detail screen

## Testing
- `flutter test` *(fails: command not found)*