### PR TITLE
Fix flutter_map options

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -110,9 +110,7 @@ class FlightDetailScreen extends StatelessWidget {
             initialZoom: zoom,
             minZoom: zoom,
             maxZoom: zoom,
-            interactionOptions: const InteractionOptions(
-              flags: InteractiveFlag.drag,
-            ),
+            interactiveFlags: InteractiveFlag.drag,
           ),
         children: [
           TileLayer(


### PR DESCRIPTION
## Summary
- remove `InteractionOptions` to maintain compatibility with flutter_map v4
- disable zoom by using `interactiveFlags`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*