### PR TITLE
Increase flight tile padding

### DIFF
--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -93,7 +93,7 @@ class FlightTile extends StatelessWidget {
         vertical: AppSpacing.xxs,
         horizontal: AppSpacing.xs,
       ),
-      padding: const EdgeInsets.all(AppSpacing.xxs / 2),
+      padding: const EdgeInsets.all(AppSpacing.xs),
       onTap: onTap,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- expand padding inside `FlightTile` for better spacing

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`