### PR TITLE
Fix progress screen parentheses error

### DIFF
--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -220,7 +220,6 @@ class _ProgressScreenState extends State<ProgressScreen>
             ),
           ],
         ),
-      ),
     );
 
     final List<Widget> items = [summaryCard, const SizedBox(height: 8)]


### PR DESCRIPTION
## Summary
- fix unmatched closing parenthesis in `ProgressScreen`

## Testing
- `dart` command not available; no tests run