### PR TITLE
Harmonize flight detail origin/destination card

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -8,6 +8,7 @@ import '../data/airport_data.dart';
 import 'add_flight_screen.dart';
 import '../widgets/skybook_app_bar.dart';
 import '../widgets/info_row.dart';
+import '../widgets/origin_destination_card.dart';
 import '../constants.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -128,33 +129,13 @@ class FlightDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final originAirport = airportByCode[flight.origin];
-    final destAirport = airportByCode[flight.destination];
-
     final items = <Widget>[
       _buildMap(context),
       const SizedBox(height: 16),
       InfoRow(title: 'Date', value: flight.date, icon: Icons.calendar_today),
-      Row(
-        children: [
-          Expanded(
-            child: InfoRow(
-              title: 'From',
-              value: flight.origin,
-              subtitle: originAirport?.city ?? '',
-              icon: Icons.flight_takeoff,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: InfoRow(
-              title: 'To',
-              value: flight.destination,
-              subtitle: destAirport?.city ?? '',
-              icon: Icons.flight_land,
-            ),
-          ),
-        ],
+      OriginDestinationCard(
+        origin: flight.origin,
+        destination: flight.destination,
       ),
       InfoRow(title: 'Aircraft', value: flight.aircraft, icon: Icons.flight),
     ];

--- a/lib/widgets/origin_destination_card.dart
+++ b/lib/widgets/origin_destination_card.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../constants.dart';
+import '../data/airport_data.dart';
+import 'skybook_card.dart';
+
+/// Displays the origin and destination airports in a single card.
+class OriginDestinationCard extends StatelessWidget {
+  static const double _airportInfoWidth = 72;
+
+  final String origin;
+  final String destination;
+
+  const OriginDestinationCard({
+    super.key,
+    required this.origin,
+    required this.destination,
+  });
+
+  Widget _airportColumn(BuildContext context, String code) {
+    final airport = airportByCode[code];
+    final city = airport?.city ?? '';
+    return SizedBox(
+      width: _airportInfoWidth,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(code, style: Theme.of(context).textTheme.titleLarge),
+          if (city.isNotEmpty)
+            Text(
+              city,
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SkyBookCard(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
+      padding: const EdgeInsets.all(AppSpacing.s),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _airportColumn(context, origin),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: const [
+                  RotatedBox(
+                    quarterTurns: 1,
+                    child: Icon(Icons.flight, size: 20),
+                  ),
+                  Expanded(child: Divider(thickness: 1)),
+                  Icon(Icons.circle, size: 8),
+                ],
+              ),
+            ),
+          ),
+          _airportColumn(context, destination),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `OriginDestinationCard` widget to display route in a single card
- replace dual `InfoRow` widgets in `FlightDetailScreen` with new card

## Testing
- `flutter test` *(fails: `flutter` not found)*