### PR TITLE
Add achievement detail screen

### DIFF
--- a/lib/screens/achievement_detail_screen.dart
+++ b/lib/screens/achievement_detail_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/achievement.dart';
+import '../theme/achievement_theme.dart';
+import '../constants.dart';
+
+class AchievementDetailScreen extends StatelessWidget {
+  final Achievement achievement;
+
+  const AchievementDetailScreen({super.key, required this.achievement});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = achievementTypeThemes[achievement.category];
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(achievement.title),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.s),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Center(
+              child: achievement.buildIcon(
+                color: theme?.color ?? Theme.of(context).colorScheme.primary,
+                size: 64,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.m),
+            Text(
+              achievement.title,
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              achievement.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const Spacer(),
+            ElevatedButton.icon(
+              onPressed: () => Share.share(achievement.description),
+              icon: const Icon(Icons.share),
+              label: const Text('Share'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -6,8 +6,7 @@ import '../utils/achievement_utils.dart';
 import '../models/achievement.dart';
 import 'package:intl/intl.dart' as intl;
 import '../widgets/skybook_app_bar.dart';
-import 'package:share_plus/share_plus.dart';
-import '../widgets/app_dialog.dart';
+import 'achievement_detail_screen.dart';
 import '../widgets/skybook_card.dart';
 import '../theme/achievement_theme.dart';
 import '../constants.dart';
@@ -228,22 +227,9 @@ class _ProgressScreenState extends State<ProgressScreen>
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
           child: SkyBookCard(
             onTap: () {
-              showDialog(
-                context: context,
-                builder: (context) => AppDialog(
-                  title: Text(a.title),
-                  content: Text(a.description),
-                  actions: [
-                    if (a.achieved)
-                      TextButton(
-                        onPressed: () => Share.share(a.description),
-                        child: const Text('Share'),
-                      ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: const Text('OK'),
-                    ),
-                  ],
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => AchievementDetailScreen(achievement: a),
                 ),
               );
             },
@@ -284,8 +270,6 @@ class _ProgressScreenState extends State<ProgressScreen>
                           color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
-                      Text('${a.progress}/${a.target}',
-                          style: Theme.of(context).textTheme.labelSmall),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Summary
- create `AchievementDetailScreen` to show achievement info and share option
- update progress screen to open detail screen and hide progress numbers

## Testing
- `flutter test` *(fails: `flutter` not installed)*