### PR TITLE
Compact achievements grid

### DIFF
--- a/lib/screens/achievements_screen.dart
+++ b/lib/screens/achievements_screen.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import '../models/flight.dart';
 import '../models/achievement.dart';
 import '../utils/achievement_utils.dart';
-import '../widgets/achievement_card.dart';
+import '../widgets/achievement_tile.dart';
+import '../widgets/skybook_card.dart';
 import '../theme/achievement_theme.dart';
 import '../constants.dart';
 
@@ -53,24 +54,31 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
         title: const Text('Achievements'),
         centerTitle: true,
       ),
-      body: ListView.builder(
+      body: ListView(
         padding: const EdgeInsets.all(AppSpacing.s),
-        itemCount: achievements.length,
-        itemBuilder: (context, index) {
-          final a = achievements[index];
-          final theme = achievementTypeThemes[a.category] ??
-              const AchievementTypeTheme(
-                  icon: Icons.emoji_events,
-                  color: Colors.grey,
-                  label: '');
-          return AchievementCard(
-            theme: theme,
-            title: a.title,
-            level: a.tier,
-            progress: a.progress,
-            maxProgress: a.target,
-          );
-        },
+        children: [
+          SkyBookCard(
+            child: GridView.count(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisCount: 3,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16,
+              children: [
+                for (final a in achievements)
+                  AchievementTile(
+                    achievement: a,
+                    theme: achievementTypeThemes[a.category] ??
+                        const AchievementTypeTheme(
+                          icon: Icons.emoji_events,
+                          color: Colors.grey,
+                          label: '',
+                        ),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/achievement_tile.dart
+++ b/lib/widgets/achievement_tile.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../constants.dart';
+import '../models/achievement.dart';
+import '../theme/achievement_theme.dart';
+import 'skybook_card.dart';
+
+/// Small tile showing basic achievement progress.
+class AchievementTile extends StatelessWidget {
+  final Achievement achievement;
+  final AchievementTypeTheme theme;
+
+  const AchievementTile({
+    super.key,
+    required this.achievement,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return SkyBookCard(
+      padding: const EdgeInsets.all(AppSpacing.xs),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          achievement.buildIcon(
+            color: achievement.achieved
+                ? theme.color
+                : colors.onSurfaceVariant,
+            size: 24,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${achievement.progress}/${achievement.target}',
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(color: colors.onSurface),
+            textAlign: TextAlign.center,
+          ),
+          Text(
+            achievement.title,
+            textAlign: TextAlign.center,
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: colors.onSurface),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `AchievementTile` widget
- display achievements in a grid within one card

## Testing
- `flutter --version` *(fails: command not found)*