### PR TITLE
Handle gallery save failures

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -132,11 +132,25 @@ class _MapScreenState extends State<MapScreen> {
     final file = await _captureMapImage();
     setState(() => _showTiles = false);
     if (file == null) return;
-    await GallerySaver.saveImage(file.path);
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Image saved to gallery')),
-      );
+    try {
+      final result = await GallerySaver.saveImage(file.path);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              result == true
+                  ? 'Image saved to gallery'
+                  : 'Failed to save image',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to save image')),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- handle exceptions when saving map screenshot to gallery

## Testing
- `flutter test` *(fails: `flutter: command not found`)*