### PR TITLE
Fix undefined AppSpacing import

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../models/flight.dart';
 import '../models/flight_storage.dart';
 import 'data_management_screen.dart';
 import '../widgets/premium_badge.dart';
+import '../constants.dart';
 
 class SettingsScreen extends StatefulWidget {
   final bool darkMode;


### PR DESCRIPTION
## Summary
- import `constants.dart` in `settings_screen.dart` so `AppSpacing` is defined

## Testing
- `flutter --version` *(fails: command not found)*