### PR TITLE
Fix premium badge layout overflow

### DIFF
--- a/lib/widgets/premium_badge.dart
+++ b/lib/widgets/premium_badge.dart
@@ -30,12 +30,16 @@ class PremiumBadge extends StatelessWidget {
       padding: const EdgeInsets.all(AppSpacing.s),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(Icons.lock, color: colors.primary),
           const SizedBox(width: AppSpacing.xs),
-          Text(
-            message,
-            style: Theme.of(context).textTheme.bodyMedium,
+          Expanded(
+            child: Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium,
+              overflow: TextOverflow.visible,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- stop PremiumBadge row from overflowing in narrow layouts

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*