### PR TITLE
Fix locked achievement icon color

### DIFF
--- a/lib/screens/achievement_detail_screen.dart
+++ b/lib/screens/achievement_detail_screen.dart
@@ -27,7 +27,10 @@ class AchievementDetailScreen extends StatelessWidget {
           children: [
             Center(
               child: achievement.buildIcon(
-                color: theme?.color ?? Theme.of(context).colorScheme.primary,
+                color: achievement.achieved
+                    ? (theme?.color ??
+                        Theme.of(context).colorScheme.primary)
+                    : Theme.of(context).colorScheme.onSurfaceVariant,
                 size: 64,
               ),
             ),

--- a/test/achievement_detail_screen_test.dart
+++ b/test/achievement_detail_screen_test.dart
@@ -80,4 +80,54 @@ void main() {
         '${intl.DateFormat.yMMMd().format(date)}';
     expect(find.text(expected), findsOneWidget);
   });
+
+  testWidgets('icon grey when achievement locked', (tester) async {
+    const achievement = Achievement(
+      id: 'test',
+      title: 'Test',
+      description: 'desc',
+      category: 'Test',
+      icon: Icons.star,
+      target: 1,
+      progress: 0,
+      achieved: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AchievementDetailScreen(achievement: achievement),
+        ),
+      ),
+    );
+
+    final context = tester.element(find.byType(AchievementDetailScreen));
+    final icon = tester.widget<Icon>(find.byIcon(Icons.star));
+    expect(icon.color, Theme.of(context).colorScheme.onSurfaceVariant);
+  });
+
+  testWidgets('icon colored when achievement unlocked', (tester) async {
+    const achievement = Achievement(
+      id: 'test',
+      title: 'Test',
+      description: 'desc',
+      category: 'Test',
+      icon: Icons.star,
+      target: 1,
+      progress: 1,
+      achieved: true,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AchievementDetailScreen(achievement: achievement),
+        ),
+      ),
+    );
+
+    final context = tester.element(find.byType(AchievementDetailScreen));
+    final icon = tester.widget<Icon>(find.byIcon(Icons.star));
+    expect(icon.color, Theme.of(context).colorScheme.primary);
+  });
 }


### PR DESCRIPTION
## Summary
- show grey icon on the achievement detail page when the achievement isn't unlocked
- test icon color on detail screen

## Testing
- `flutter test` *(fails: `flutter: command not found`)*