### PR TITLE
Patch gallery_saver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
    ```sh
    flutter pub get
    ```
+   After fetching packages, run the helper script below to patch the
+   `gallery_saver` plugin so it declares an Android namespace when built with
+   recent versions of the Android Gradle Plugin:
+   ```sh
+   bash scripts/patch_gallery_saver.sh
+   ```
    Ensure the `home_widget` package is kept at version `0.5.0` in
    `pubspec.yaml`. If this version is upgraded, iOS builds may fail due to the
    missing `WidgetConfigurationIntent` definition required by newer releases.

--- a/scripts/patch_gallery_saver.sh
+++ b/scripts/patch_gallery_saver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Patch gallery_saver plugin to add namespace for AGP 8+
+set -e
+PLUGIN_VERSION="2.3.2"
+PLUGIN_DIR="$HOME/.pub-cache/hosted/pub.dev/gallery_saver-$PLUGIN_VERSION/android"
+GRADLE_FILE="$PLUGIN_DIR/build.gradle"
+
+if [ -f "$GRADLE_FILE" ]; then
+  if ! grep -q "namespace" "$GRADLE_FILE"; then
+    sed -i '/^android {/a\\    namespace "com.example.gallery_saver"' "$GRADLE_FILE"
+    echo "Added namespace to $GRADLE_FILE"
+  else
+    echo "Namespace already present in $GRADLE_FILE"
+  fi
+else
+  echo "gallery_saver plugin not found at $GRADLE_FILE"
+fi


### PR DESCRIPTION
## Summary
- add a helper script to inject a namespace into the `gallery_saver` plugin
- document running the script after `flutter pub get`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*