### PR TITLE
Display achievement progress in detail screen

### DIFF
--- a/lib/screens/achievement_detail_screen.dart
+++ b/lib/screens/achievement_detail_screen.dart
@@ -56,6 +56,33 @@ class AchievementDetailScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
               ),
+            const SizedBox(height: AppSpacing.m),
+            Semantics(
+              label:
+                  'Progress: ${achievement.progress} of ${achievement.target}',
+              child: Column(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: achievement.target == 0
+                          ? 0
+                          : achievement.progress / achievement.target,
+                      minHeight: 6,
+                      backgroundColor: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.12),
+                      color: theme?.color ??
+                          Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text('${achievement.progress}/${achievement.target}',
+                      style: Theme.of(context).textTheme.labelMedium),
+                ],
+              ),
+            ),
             const Spacer(),
             ElevatedButton.icon(
               onPressed: achievement.achieved

--- a/lib/widgets/achievement_tile.dart
+++ b/lib/widgets/achievement_tile.dart
@@ -34,13 +34,20 @@ class AchievementTile extends StatelessWidget {
             size: 24,
           ),
           const SizedBox(height: 4),
-          Text(
-            '${achievement.progress}/${achievement.target}',
-            style: Theme.of(context)
-                .textTheme
-                .titleMedium
-                ?.copyWith(color: colors.onSurface),
-            textAlign: TextAlign.center,
+          Semantics(
+            label: 'Progress: ${achievement.progress} of ${achievement.target}',
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: achievement.target == 0
+                    ? 0
+                    : achievement.progress / achievement.target,
+                minHeight: 6,
+                backgroundColor:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
+                color: theme.color,
+              ),
+            ),
           ),
           Text(
             achievement.title,


### PR DESCRIPTION
## Summary
- change small achievement tiles to use a progress bar
- show progress with number on the AchievementDetailScreen

## Testing
- `flutter test` *(fails: `flutter` not found)*