### PR TITLE
Add new achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SkyBook is a simple flight logbook mobile app built with Flutter. It lets you re
 - See your top airlines in the Status section
 - Analyze seat location preferences with a dedicated chart in the Status section
 - View total CO₂ emissions per passenger in the Status section
-- Track progress with detailed achievements for flight counts, distance and destinations, including advanced tiers like Jet Setter, **Sky Legend**, World Explorer and Airport Master
+- Track progress with detailed achievements for flight counts, distance, fleet diversity and airline variety, including advanced tiers like Jet Setter, **Sky Legend**, World Explorer and Airport Master
 - Switch between light and dark themes
 - Theme preference is saved so your choice is remembered
 - Enable a developer section with an option to clear local data

--- a/lib/utils/achievement_utils.dart
+++ b/lib/utils/achievement_utils.dart
@@ -38,6 +38,10 @@ List<Achievement> calculateAchievements(List<Flight> flights,
   final airportsVisited = <String>{};
   final countriesVisited = <String>{};
   final classesFlown = <String>{};
+  final aircraftFlown = <String>{};
+  final airlinesFlown = <String>{};
+  int seatReviews = 0;
+  int businessTrips = 0;
   double totalCarbon = 0;
 
   for (final f in flights) {
@@ -54,6 +58,10 @@ List<Achievement> calculateAchievements(List<Flight> flights,
     if (f.travelClass.isNotEmpty) {
       classesFlown.add(f.travelClass);
     }
+    aircraftFlown.add(f.aircraft);
+    if (f.airline.isNotEmpty) airlinesFlown.add(f.airline);
+    if (f.seatRating > 0) seatReviews++;
+    if (f.isBusiness) businessTrips++;
     final carbon = f.carbonKg.isNaN ? 0 : f.carbonKg;
     totalCarbon += carbon;
 
@@ -281,6 +289,50 @@ List<Achievement> calculateAchievements(List<Flight> flights,
       200,
       tier: 3,
       unlockedAt: unlocked['airportConqueror'],
+    ),
+    _progress(
+      'fleetFamiliar',
+      'Fleet Familiar',
+      'Fly 5 different aircraft models',
+      'Flights',
+      Icons.airplanemode_active,
+      'assets/badges/plane.png',
+      aircraftFlown.length,
+      5,
+      unlockedAt: unlocked['fleetFamiliar'],
+    ),
+    _progress(
+      'airlineHopper',
+      'Airline Hopper',
+      'Fly with 5 different airlines',
+      'Flights',
+      Icons.airlines,
+      'assets/badges/plane.png',
+      airlinesFlown.length,
+      5,
+      unlockedAt: unlocked['airlineHopper'],
+    ),
+    _progress(
+      'seatCritic',
+      'Seat Critic',
+      'Rate seats on 10 flights',
+      'Flights',
+      Icons.event_seat,
+      'assets/badges/plane.png',
+      seatReviews,
+      10,
+      unlockedAt: unlocked['seatCritic'],
+    ),
+    _progress(
+      'businessPro',
+      'Business Pro',
+      'Log 10 business trips',
+      'Flights',
+      Icons.business_center,
+      'assets/badges/plane.png',
+      businessTrips,
+      10,
+      unlockedAt: unlocked['businessPro'],
     ),
   ];
 }

--- a/test/achievement_utils_test.dart
+++ b/test/achievement_utils_test.dart
@@ -52,6 +52,40 @@ Flight _flightWithClass(
   );
 }
 
+Flight _customFlight(
+  String id,
+  String origin,
+  String destination,
+  double distance, {
+  String aircraft = 'Boeing 737',
+  String manufacturer = 'Boeing',
+  String airline = '',
+  int seatRating = 0,
+  bool isBusiness = false,
+}) {
+  return Flight(
+    id: id,
+    date: '2023-01-01',
+    aircraft: aircraft,
+    manufacturer: manufacturer,
+    airline: airline,
+    callsign: '',
+    duration: '',
+    notes: '',
+    origin: origin,
+    destination: destination,
+    travelClass: '',
+    seatNumber: '',
+    seatLocation: '',
+    distanceKm: distance,
+    carbonKg: 0,
+    isBusiness: isBusiness,
+    seatRating: seatRating,
+    originRating: 0,
+    destinationRating: 0,
+  );
+}
+
 void main() {
   group('calculateAchievements', () {
     test('no flights yields zero progress', () {
@@ -221,6 +255,77 @@ void main() {
       expect(legend.achieved, isTrue);
       expect(conqueror.achieved, isTrue);
       expect(flyer200.achieved, isTrue);
+    });
+
+    test('fleet familiar counts unique aircraft', () {
+      final flights = [
+        _customFlight('1', 'JFK', 'LAX', 4000, aircraft: 'A320', manufacturer: 'Airbus'),
+        _customFlight('2', 'LAX', 'JFK', 4000, aircraft: '737', manufacturer: 'Boeing'),
+        _customFlight('3', 'JFK', 'LAX', 4000, aircraft: 'A330', manufacturer: 'Airbus'),
+      ];
+
+      final achievements = calculateAchievements(flights);
+      final fleet = achievements.firstWhere((a) => a.id == 'fleetFamiliar');
+
+      expect(fleet.progress, 3);
+      expect(fleet.achieved, isFalse);
+    });
+
+    test('airline hopper unlocks with five airlines', () {
+      final flights = List.generate(
+        5,
+        (i) => _customFlight(
+          '${i + 1}',
+          'JFK',
+          'LAX',
+          4000,
+          airline: 'Airline ${i + 1}',
+        ),
+      );
+
+      final achievements = calculateAchievements(flights);
+      final hopper = achievements.firstWhere((a) => a.id == 'airlineHopper');
+
+      expect(hopper.progress, 5);
+      expect(hopper.achieved, isTrue);
+    });
+
+    test('seat critic counts rated flights', () {
+      final flights = List.generate(
+        10,
+        (i) => _customFlight(
+          '${i + 1}',
+          'JFK',
+          'LAX',
+          4000,
+          seatRating: 4,
+        ),
+      );
+
+      final achievements = calculateAchievements(flights);
+      final critic = achievements.firstWhere((a) => a.id == 'seatCritic');
+
+      expect(critic.progress, 10);
+      expect(critic.achieved, isTrue);
+    });
+
+    test('business pro unlocks with business trips', () {
+      final flights = List.generate(
+        10,
+        (i) => _customFlight(
+          '${i + 1}',
+          'JFK',
+          'LAX',
+          4000,
+          isBusiness: true,
+        ),
+      );
+
+      final achievements = calculateAchievements(flights);
+      final pro = achievements.firstWhere((a) => a.id == 'businessPro');
+
+      expect(pro.progress, 10);
+      expect(pro.achieved, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- expand README features description
- calculate additional achievement metrics
- support fleet, airline, seat review, and business trip achievements
- verify new achievements in tests

## Testing
- `flutter test` *(fails: command not found)*