### PR TITLE
Enable pinch zoom gestures on maps

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -114,7 +114,7 @@ class FlightDetailScreen extends StatelessWidget {
             minZoom: zoom,
             maxZoom: zoom,
             interactionOptions: const InteractionOptions(
-              flags: InteractiveFlag.drag,
+              flags: InteractiveFlag.drag | InteractiveFlag.pinchZoom,
             ),
           ),
         children: [

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -227,7 +227,7 @@ class _MapScreenState extends State<MapScreen> {
                   _zoom = pos.zoom ?? _zoom;
                 },
                 interactionOptions: const InteractionOptions(
-                  flags: InteractiveFlag.drag,
+                  flags: InteractiveFlag.drag | InteractiveFlag.pinchZoom,
                 ),
               ),
               children: [


### PR DESCRIPTION
## Summary
- allow pinch zoom interaction on Map screen
- enable pinch zoom for map preview in flight details

## Testing
- `flutter test` *(fails: command not found)*