### PR TITLE
Fix dark mode tile contrast

### DIFF
--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -31,7 +31,8 @@ class FlightTile extends StatelessWidget {
   }
 
   Color _colorForClass(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
     switch (flight.travelClass) {
       case 'Premium':
         return isDark ? Colors.indigo.shade700 : Colors.indigo.shade50;
@@ -40,7 +41,7 @@ class FlightTile extends StatelessWidget {
       case 'First':
         return isDark ? Colors.amber.shade700 : Colors.amber.shade50;
       default:
-        return Theme.of(context).cardColor;
+        return isDark ? theme.colorScheme.surfaceVariant : theme.cardColor;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure economy flight tiles use surfaceVariant color in dark mode

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a1aa01898832ca38308bd4fe72031