### PR TITLE
Enable wallet import on Add Flight screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,7 +108,10 @@ class _SkyBookAppState extends State<SkyBookApp> {
     if (type == 'add_flight') {
       final newFlight = await _navigatorKey.currentState?.push<Flight>(
         MaterialPageRoute(
-          builder: (_) => AddFlightScreen(flights: _flightsNotifier.value),
+          builder: (_) => AddFlightScreen(
+            flights: _flightsNotifier.value,
+            premiumNotifier: _premiumNotifier,
+          ),
         ),
       );
       if (newFlight != null) {

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -28,7 +28,12 @@ class FlightDetailScreen extends StatelessWidget {
   Future<void> _edit(BuildContext context) async {
     final result = await Navigator.of(context).push<dynamic>(
       MaterialPageRoute(
-          builder: (_) => AddFlightScreen(flight: flight, flights: flights)),
+        builder: (_) => AddFlightScreen(
+          flight: flight,
+          flights: flights,
+          premiumNotifier: premiumNotifier,
+        ),
+      ),
     );
     if (result != null) {
       Navigator.of(context).pop(result);

--- a/lib/screens/flight_screen.dart
+++ b/lib/screens/flight_screen.dart
@@ -142,7 +142,11 @@ class _FlightScreenState extends State<FlightScreen> {
   Future<void> _addFlight() async {
     final newFlight = await Navigator.of(context).push<Flight>(
       MaterialPageRoute(
-          builder: (_) => AddFlightScreen(flights: _allFlights)),
+        builder: (_) => AddFlightScreen(
+          flights: _allFlights,
+          premiumNotifier: widget.premiumNotifier,
+        ),
+      ),
     );
     if (newFlight != null) {
       _allFlights = List<Flight>.from(_allFlights)..add(newFlight);

--- a/test/add_flight_screen_test.dart
+++ b/test/add_flight_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skybook/screens/add_flight_screen.dart';
+import 'package:skybook/widgets/premium_badge.dart';
+
+void main() {
+  const channel = MethodChannel('skybook/wallet');
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      if (methodCall.method == 'getBoardingPass') {
+        return 'M1DOE/JANE           AA123 JFK LAX 2024-02-01';
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('wallet import available for premium users', (tester) async {
+    final premium = ValueNotifier<bool>(true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AddFlightScreen(flights: const [], premiumNotifier: premium),
+        ),
+      ),
+    );
+
+    expect(find.text('Import from Wallet'), findsOneWidget);
+    expect(find.byType(PremiumBadge), findsNothing);
+
+    await tester.tap(find.text('Import from Wallet'));
+    await tester.pumpAndSettle();
+
+    final state = tester.state(find.byType(AddFlightScreen)) as dynamic;
+    expect(state._flightNumberController.text, 'AA123');
+    expect(state._originController.text, 'JFK');
+    expect(state._destinationController.text, 'LAX');
+  });
+
+  testWidgets('wallet import gated for free users', (tester) async {
+    final premium = ValueNotifier<bool>(false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AddFlightScreen(flights: const [], premiumNotifier: premium),
+        ),
+      ),
+    );
+
+    expect(find.byType(PremiumBadge), findsOneWidget);
+    expect(find.text('Import from Wallet'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add premium-gated "Import from Wallet" option to `AddFlightScreen`
- wire premium notifier through related screens
- handle wallet import via `WalletService`
- test new functionality

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a1d23dcd0832cb989856436df0d4c