### PR TITLE
Expand seed airlines list

### DIFF
--- a/lib/data/airline_data.dart
+++ b/lib/data/airline_data.dart
@@ -65,6 +65,11 @@ const List<Airline> seedAirlines = [
   Airline(name: 'Virgin Australia', callsign: 'VOZ', code: 'VA'),
   Airline(name: 'Hawaiian Airlines', callsign: 'HAL', code: 'HA'),
   Airline(name: 'Copa Airlines', callsign: 'CMP', code: 'CM'),
+  Airline(name: 'Austrian Airlines', callsign: 'AUA', code: 'OS'),
+  Airline(name: 'Sun Country Airlines', callsign: 'SCX', code: 'SY'),
+  Airline(name: 'Norwegian Air Shuttle', callsign: 'NAX', code: 'DY'),
+  Airline(name: 'Air Tahiti Nui', callsign: 'THT', code: 'TN'),
+  Airline(name: 'IndiGo', callsign: 'IGO', code: '6E'),
 ];
 
 List<Airline> airlines = [];


### PR DESCRIPTION
## Summary
- add several more sample airlines to the seed data

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ac76155a4832c93011bd3c9d45baa