### PR TITLE
Add expand arrow to Status screen cards

### DIFF
--- a/lib/screens/status_screen.dart
+++ b/lib/screens/status_screen.dart
@@ -711,10 +711,23 @@ class _ExpandableBarListTileState extends State<_ExpandableBarListTile> {
       );
     }
 
+    final arrowIcon = Icon(
+      _expanded ? Icons.expand_less : Icons.expand_more,
+      size: 16,
+      color: Theme.of(context).colorScheme.onSurface,
+    );
+
     return SkyBookCard(
       onTap: _toggle,
       padding: const EdgeInsets.all(AppSpacing.s),
-      child: content,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(child: content),
+          const SizedBox(width: 4),
+          arrowIcon,
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add an expand/collapse arrow indicator to `_ExpandableBarListTile`

## Testing
- `dart format -o none lib/screens/status_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ac8cab428832c9707aed5ef084b25