### PR TITLE
Allow searching airports by name

### DIFF
--- a/lib/screens/add_flight_screen.dart
+++ b/lib/screens/add_flight_screen.dart
@@ -421,7 +421,6 @@ class _AddFlightScreenState extends State<AddFlightScreen> {
           controller: textEditingController,
           focusNode: fieldFocusNode,
           inputFormatters: [
-            LengthLimitingTextInputFormatter(3),
             UpperCaseTextFormatter(),
           ],
           decoration: InputDecoration(


### PR DESCRIPTION
## Summary
- remove 3-letter limit for airport fields so users can search by name

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ad382dc64832cb9b2c2a9c887194e