### PR TITLE
Move route tile under map

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -167,11 +167,11 @@ class FlightDetailScreen extends StatelessWidget {
     final items = <Widget>[
       _buildMap(context),
       const SizedBox(height: 16),
-      InfoRow(title: 'Date', value: flight.date, icon: Icons.calendar_today),
       OriginDestinationCard(
         origin: flight.origin,
         destination: flight.destination,
       ),
+      InfoRow(title: 'Date', value: flight.date, icon: Icons.calendar_today),
       InfoRow(title: 'Aircraft', value: flight.aircraft, icon: Icons.flight),
     ];
 


### PR DESCRIPTION
## Summary
- reorder widgets on flight detail screen so the route card appears directly under the map

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad3af0cf8832c8e2cc8a19f7307f9