### PR TITLE
Fix const constructor error

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -23,7 +23,7 @@ class FlightDetailScreen extends StatelessWidget {
   final List<Flight> flights;
   final GlobalKey _shareKey = GlobalKey();
 
-  const FlightDetailScreen({
+  FlightDetailScreen({
     super.key,
     required this.flight,
     required this.premiumNotifier,


### PR DESCRIPTION
## Summary
- remove `const` from `FlightDetailScreen` constructor to avoid a const field
  error when `_shareKey` is assigned `GlobalKey()`

## Testing
- `flutter test` *(fails: `flutter` not found)*
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683adbd73d24832c98bedc839d06431e