### PR TITLE
Fix divider visibility for flight cards in dark mode

### DIFF
--- a/lib/widgets/flight_tile.dart
+++ b/lib/widgets/flight_tile.dart
@@ -139,13 +139,18 @@ class FlightTile extends StatelessWidget {
                           textAlign: TextAlign.center,
                         ),
                       Row(
-                        children: const [
-                          RotatedBox(
+                        children: [
+                          const RotatedBox(
                             quarterTurns: 1,
                             child: Icon(Icons.flight, size: 20),
                           ),
-                          Expanded(child: Divider(thickness: 1)),
-                          Icon(Icons.circle, size: 8),
+                          Expanded(
+                            child: Divider(
+                              thickness: 1,
+                              color: Theme.of(context).colorScheme.outline,
+                            ),
+                          ),
+                          const Icon(Icons.circle, size: 8),
                         ],
                       ),
                       if (flight.aircraft.isNotEmpty)

--- a/lib/widgets/origin_destination_card.dart
+++ b/lib/widgets/origin_destination_card.dart
@@ -52,13 +52,18 @@ class OriginDestinationCard extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8),
               child: Row(
-                children: const [
-                  RotatedBox(
+                children: [
+                  const RotatedBox(
                     quarterTurns: 1,
                     child: Icon(Icons.flight, size: 20),
                   ),
-                  Expanded(child: Divider(thickness: 1)),
-                  Icon(Icons.circle, size: 8),
+                  Expanded(
+                    child: Divider(
+                      thickness: 1,
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  const Icon(Icons.circle, size: 8),
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- keep the divider visible on flight cards when using dark theme

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b074b4b04832c8c5435af1efbf0d0