### PR TITLE
Fix tile provider const usage

### DIFF
--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -154,7 +154,7 @@ class FlightDetailScreen extends StatelessWidget {
                 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
             subdomains: const ['a', 'b', 'c', 'd'],
             userAgentPackageName: 'com.example.app',
-            tileProvider: const CachedTileProvider(),
+            tileProvider: CachedTileProvider(),
           ),
           PolylineLayer(polylines: lines),
           MarkerLayer(markers: markers),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -235,7 +235,7 @@ class _MapScreenState extends State<MapScreen> {
                 TileLayer(
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'com.example.app',
-                  tileProvider: const CachedTileProvider(),
+                  tileProvider: CachedTileProvider(),
                 ),
                 PolylineLayer(polylines: lines),
                 MarkerLayer(markers: markers),

--- a/lib/utils/cached_tile_provider.dart
+++ b/lib/utils/cached_tile_provider.dart
@@ -5,11 +5,16 @@ import 'package:flutter_map/flutter_map.dart';
 /// A [TileProvider] that caches tiles to disk so previously viewed
 /// areas remain available offline.
 class CachedTileProvider extends TileProvider {
-  const CachedTileProvider();
+  CachedTileProvider();
 
   @override
   ImageProvider getImage(TileCoordinates coordinates, TileLayer tileLayer) {
-    var url = tileLayer.urlTemplate
+    final template = tileLayer.urlTemplate;
+    if (template == null) {
+      throw ArgumentError('TileLayer.urlTemplate cannot be null');
+    }
+
+    var url = template
         .replaceFirst('{x}', '${coordinates.x}')
         .replaceFirst('{y}', '${coordinates.y}')
         .replaceFirst('{z}', '${coordinates.z}');


### PR DESCRIPTION
## Summary
- make CachedTileProvider non-const and guard url template
- update map screens to use the new constructor

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683b1482f9d0832c8cfe01522bf39738